### PR TITLE
Update target to ES2024

### DIFF
--- a/.changeset/fresh-taxes-tell.md
+++ b/.changeset/fresh-taxes-tell.md
@@ -1,0 +1,5 @@
+---
+"@becklyn/tsconfig": minor
+---
+
+Update target to ES2024

--- a/packages/tsconfig/base.json
+++ b/packages/tsconfig/base.json
@@ -8,7 +8,7 @@
         "incremental": false,
         "isolatedModules": true,
         "lib": [
-            "es2022",
+            "es2024",
             "DOM",
             "DOM.Iterable"
         ],
@@ -22,6 +22,6 @@
         "skipLibCheck": true,
         "strict": true,
         "strictNullChecks": true,
-        "target": "ES2022"
+        "target": "ES2024"
     }
 }


### PR DESCRIPTION
With TS 5.7 and Nodejs v22 ES2024 is fully supported, see:

https://node.green/#ES2024
https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-7.html#support-for---target-es2024-and---lib-es2024