### PR TITLE
Fix list function usage in transition mixin for SCSS animations

### DIFF
--- a/.changeset/puny-crabs-end.md
+++ b/.changeset/puny-crabs-end.md
@@ -1,0 +1,5 @@
+---
+"@becklyn/next": patch
+---
+
+Fix list function usage in transition mixin for SCSS animations

--- a/packages/next/scss/animation.scss
+++ b/packages/next/scss/animation.scss
@@ -1,13 +1,15 @@
+@use "sass:list";
+
 @mixin transition($properties, $duration: 0.15s, $easing: ease-in-out, $will-change: true) {
     @if $will-change {
-        will-change: join($properties, (), "comma");
+        will-change: list.join($properties, (), "comma");
     }
 
-    @if (1 == length($properties)) {
+    @if (1 == list.length($properties)) {
         transition: #{$duration} #{$easing} #{$properties};
     } @else {
         transition: #{$duration} #{$easing};
-        transition-property: join($properties, (), "comma");
+        transition-property: list.join($properties, (), "comma");
     }
 }
 


### PR DESCRIPTION
Fix list function usage in transition mixin for SCSS animations to prevent sass warning