### PR TITLE
silence triple-slash-reference rule

### DIFF
--- a/.changeset/fancy-corners-fetch.md
+++ b/.changeset/fancy-corners-fetch.md
@@ -1,0 +1,5 @@
+---
+"@becklyn/eslint": minor
+---
+
+Ignore @typescript-eslint/triple-slash-reference rule in next-env.d.ts

--- a/packages/eslint/next.js
+++ b/packages/eslint/next.js
@@ -50,4 +50,10 @@ export const nextJsConfig = [
             ],
         },
     },
+    {
+        files: ["next-env.d.ts"],
+        rules: {
+            "@typescript-eslint/triple-slash-reference": "off",
+        }
+    },
 ];


### PR DESCRIPTION
After a nextjs update this rule leads to failed pipelines so we ignore it.