### PR TITLE
Forward data-tracking-* attributes on websiteClick

### DIFF
--- a/.changeset/heavy-pumas-forward.md
+++ b/.changeset/heavy-pumas-forward.md
@@ -1,0 +1,23 @@
+---
+"@becklyn/next": minor
+---
+
+Forward `data-tracking-*` attributes as additional keys on the `websiteClick` event.
+
+`useDataEventForwarder` now walks up from the click target and collects every
+`data-tracking-*` attribute it finds, camelCasing the remainder of the attribute name into
+the pushed event. The nearest ancestor wins, so page-level context can live on `<html>`
+while element-level context sits on the clicked element:
+
+```html
+<html data-tracking-page-type="location-details-page">
+    <a href="tel:..." data-event="ga-button" data-tracking-service-type="workshop-service">
+```
+
+```js
+{ event: "websiteClick", pageType: "location-details-page", serviceType: "workshop-service", ... }
+```
+
+The event is still only pushed for elements below a `[data-event]` ancestor, and the
+existing `event`, `dataEvent`, `classList`, `className` and `text` keys always take
+precedence.

--- a/packages/next/tracking/gtm/index.tsx
+++ b/packages/next/tracking/gtm/index.tsx
@@ -138,7 +138,7 @@ export const collectTrackingContext = (target: Element) => {
 
             const key = toCamelCase(name.slice(DATA_TRACKING_PREFIX.length));
 
-            if (!key || key in context) {
+            if (!key || Object.prototype.hasOwnProperty.call(context, key)) {
                 continue;
             }
 

--- a/packages/next/tracking/gtm/index.tsx
+++ b/packages/next/tracking/gtm/index.tsx
@@ -120,6 +120,37 @@ export const useLazyDataLayer = () => {
     };
 };
 
+export const DATA_TRACKING_PREFIX = "data-tracking-";
+
+const toCamelCase = (value: string) =>
+    value.replace(/-([a-z0-9])/g, (_, character: string) => character.toUpperCase());
+
+export const collectTrackingContext = (target: Element) => {
+    const context: Record<string, string> = {};
+
+    let element: Element | null = target;
+
+    while (element) {
+        for (const { name, value } of Array.from(element.attributes)) {
+            if (!name.startsWith(DATA_TRACKING_PREFIX)) {
+                continue;
+            }
+
+            const key = toCamelCase(name.slice(DATA_TRACKING_PREFIX.length));
+
+            if (!key || key in context) {
+                continue;
+            }
+
+            context[key] = value;
+        }
+
+        element = element.parentElement;
+    }
+
+    return context;
+};
+
 export const useDataEventForwarder = (hasConsent: boolean) => {
     useLayoutEffect(() => {
         const captureDataEvent = (event: MouseEvent) => {
@@ -145,6 +176,7 @@ export const useDataEventForwarder = (hasConsent: boolean) => {
             const text = "innerText" in element ? (element.innerText as string) : undefined;
 
             const data = {
+                ...collectTrackingContext(target),
                 event: "websiteClick",
                 dataEvent,
                 classList,


### PR DESCRIPTION
## Why

`useDataEventForwarder` pushes `websiteClick` with a fixed shape (`dataEvent`, `classList`, `className`, `text`). Consumers that want to segment those clicks — e.g. separating phone-number clicks by page type and by service — have no way to attach context, because the only thing the forwarder reads is `data-event`.

## What

The forwarder now walks up from the click target and collects every `data-tracking-*` attribute it finds, camelCasing the remainder of the attribute name into the pushed event. The nearest ancestor wins, so page-level context can live on `<html>` while element-level context sits on the clicked element:

```html
<html data-tracking-page-type="location-details-page">
    <a href="tel:..." data-event="ga-button" data-tracking-service-type="workshop-service">
```

```js
{ event: "websiteClick", pageType: "location-details-page", serviceType: "workshop-service", dataEvent: "ga-button", ... }
```

`collectTrackingContext` and `DATA_TRACKING_PREFIX` are exported so consumers can reuse the resolution rule.

## Compatibility

Backwards compatible. The `[data-event]` gate is unchanged, plain `data-*` attributes are ignored, and the reserved keys (`event`, `dataEvent`, `classList`, `className`, `text`) always take precedence over collected context.

## Verification

`npm run lint` and `npm run build` green in `packages/next`. The built `dist/es` output was exercised in jsdom to confirm nearest-ancestor resolution, camelCasing, inner-overrides-outer, and that plain `data-*` attributes are not picked up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)