### PR TITLE
fix(deployment-protection): require inline middleware matcher

### DIFF
--- a/.changeset/inline-middleware-matcher.md
+++ b/.changeset/inline-middleware-matcher.md
@@ -1,0 +1,5 @@
+---
+"@becklyn/deployment-protection": minor
+---
+
+Remove `deploymentProtectionMatcher` export. Next.js requires `config.matcher` to be a string literal in the local middleware/proxy file and cannot analyze values imported from a package. Document the recommended matcher inline in the README instead.

--- a/packages/deployment-protection/README.md
+++ b/packages/deployment-protection/README.md
@@ -23,33 +23,34 @@ npm i @becklyn/deployment-protection
 
 ### 1. Middleware / proxy
 
+Next.js requires `config.matcher` to be a **string literal in the local middleware/proxy file**.
+It cannot be imported from a package (Next analyzes the matcher statically at build time).
+
 **Next.js 16+ (`proxy.ts`):**
 
 ```ts
-import {
-    deploymentProtectionMatcher,
-    withDeploymentProtection,
-} from "@becklyn/deployment-protection";
+import { withDeploymentProtection } from "@becklyn/deployment-protection";
 
 export const proxy = withDeploymentProtection();
 
 export const config = {
-    matcher: deploymentProtectionMatcher,
+    matcher: [
+        "/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp|ico|css|js|map|txt|xml|woff2?)$).*)",
+    ],
 };
 ```
 
 **Next.js ≤15 (`middleware.ts`):**
 
 ```ts
-import {
-    deploymentProtectionMatcher,
-    withDeploymentProtection,
-} from "@becklyn/deployment-protection";
+import { withDeploymentProtection } from "@becklyn/deployment-protection";
 
 export default withDeploymentProtection();
 
 export const config = {
-    matcher: deploymentProtectionMatcher,
+    matcher: [
+        "/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp|ico|css|js|map|txt|xml|woff2?)$).*)",
+    ],
 };
 ```
 
@@ -135,7 +136,6 @@ Redeploy. Middleware stays installed but is a no-op.
 
 ```ts
 import {
-    deploymentProtectionMatcher,
     handleDeploymentProtection,
     resolveConfig,
     withDeploymentProtection,
@@ -144,7 +144,12 @@ import {
 
 - `withDeploymentProtection(options?)` / `withDeploymentProtection(next, options?)` — middleware/proxy factory
 - `handleDeploymentProtection(request, options?)` — framework-agnostic core (`null` = continue)
-- `deploymentProtectionMatcher` — recommended matcher array
+
+Recommended matcher (must be pasted as a string literal in your middleware/proxy file — see above):
+
+```ts
+"/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp|ico|css|js|map|txt|xml|woff2?)$).*)";
+```
 
 ## Security notes
 

--- a/packages/deployment-protection/src/constants.ts
+++ b/packages/deployment-protection/src/constants.ts
@@ -13,8 +13,3 @@ export const BYPASS_HEADER = "x-vercel-protection-bypass";
 export const SET_BYPASS_COOKIE_HEADER = "x-vercel-set-bypass-cookie";
 
 export const DEFAULT_SESSION_TTL_SECONDS = 60 * 60 * 24 * 14; // 14 days
-
-/** Recommended Next.js matcher for full-site protection. */
-export const deploymentProtectionMatcher = [
-    "/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp|ico|css|js|map|txt|xml|woff2?)$).*)",
-];

--- a/packages/deployment-protection/src/index.ts
+++ b/packages/deployment-protection/src/index.ts
@@ -1,9 +1,4 @@
-export {
-    deploymentProtectionMatcher,
-    INTERNAL_PATH_PREFIX,
-    VERCEL_AUTHORIZE_PATH,
-    VERCEL_CALLBACK_PATH,
-} from "./constants";
+export { INTERNAL_PATH_PREFIX, VERCEL_AUTHORIZE_PATH, VERCEL_CALLBACK_PATH } from "./constants";
 export { handleDeploymentProtection } from "./handler";
 export { withDeploymentProtection } from "./middleware";
 export { resolveConfig, hasPasswordAuth, hasVercelAuth, isProtectionActive } from "./config";

--- a/packages/deployment-protection/src/middleware.ts
+++ b/packages/deployment-protection/src/middleware.ts
@@ -1,5 +1,4 @@
 import { type NextRequest, NextResponse } from "next/server";
-import { deploymentProtectionMatcher } from "./constants";
 import { handleDeploymentProtection } from "./handler";
 import type { DeploymentProtectionOptions } from "./types";
 
@@ -82,18 +81,30 @@ function copyHeaders(from: Response, to: NextResponse, skipLocation: boolean): v
 /**
  * Next.js middleware / proxy wrapper.
  *
+ * Next.js only accepts a statically analyzable `config.matcher` in the local
+ * middleware/proxy file. Do not import a matcher from this package — paste the
+ * recommended pattern inline (see README).
+ *
  * @example middleware.ts (Next ≤15)
  * ```ts
- * import {withDeploymentProtection, deploymentProtectionMatcher} from "@becklyn/deployment-protection";
+ * import {withDeploymentProtection} from "@becklyn/deployment-protection";
  * export default withDeploymentProtection();
- * export const config = { matcher: deploymentProtectionMatcher };
+ * export const config = {
+ *   matcher: [
+ *     "/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp|ico|css|js|map|txt|xml|woff2?)$).*)",
+ *   ],
+ * };
  * ```
  *
  * @example proxy.ts (Next 16+)
  * ```ts
- * import {withDeploymentProtection, deploymentProtectionMatcher} from "@becklyn/deployment-protection";
+ * import {withDeploymentProtection} from "@becklyn/deployment-protection";
  * export const proxy = withDeploymentProtection();
- * export const config = { matcher: deploymentProtectionMatcher };
+ * export const config = {
+ *   matcher: [
+ *     "/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp|ico|css|js|map|txt|xml|woff2?)$).*)",
+ *   ],
+ * };
  * ```
  */
 export function withDeploymentProtection(...args: WithDeploymentProtectionArgs) {
@@ -129,5 +140,3 @@ export function withDeploymentProtection(...args: WithDeploymentProtectionArgs) 
         return NextResponse.next();
     };
 }
-
-export { deploymentProtectionMatcher };


### PR DESCRIPTION
## Summary

Next.js only accepts a **statically analyzable** `config.matcher` in the local `middleware.ts` / `proxy.ts` file. Importing `deploymentProtectionMatcher` from `@becklyn/deployment-protection` does not work at build time.

## Changes

- Remove the `deploymentProtectionMatcher` export from the public API
- Document that the recommended matcher must be pasted as a string literal in the consumer’s middleware/proxy file
- Update JSDoc examples on `withDeploymentProtection` accordingly
- Add a changeset

## Usage after this change

```ts
import { withDeploymentProtection } from "@becklyn/deployment-protection";

export const proxy = withDeploymentProtection(); // or `export default` on Next ≤15

export const config = {
  matcher: [
    "/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp|ico|css|js|map|txt|xml|woff2?)$).*)",
  ],
};
```

## Breaking change

`deploymentProtectionMatcher` is no longer exported. Consumers must inline the matcher string (which was already required for Next.js to pick it up correctly).