### PR TITLE
feat(deployment-protection): central auth-proxy for Sign in with Vercel

### DIFF
--- a/.changeset/auth-proxy-handoff.md
+++ b/.changeset/auth-proxy-handoff.md
@@ -1,0 +1,5 @@
+---
+"@becklyn/deployment-protection": minor
+---
+
+Add central auth-proxy support for Sign in with Vercel so projects no longer register per-host OAuth callback URLs. Protected apps can set `DEPLOYMENT_PROTECTION_AUTH_PROXY_URL` and share a handoff secret; the new private `deployment-protection-auth-proxy` app owns the single Vercel callback.

--- a/package-lock.json
+++ b/package-lock.json
@@ -586,6 +586,10 @@
             "resolved": "packages/deployment-protection",
             "link": true
         },
+        "node_modules/@becklyn/deployment-protection-auth-proxy": {
+            "resolved": "packages/deployment-protection-auth-proxy",
+            "link": true
+        },
         "node_modules/@becklyn/docs": {
             "resolved": "docs",
             "link": true
@@ -15432,7 +15436,7 @@
         },
         "packages/deployment-protection": {
             "name": "@becklyn/deployment-protection",
-            "version": "0.0.0",
+            "version": "0.2.0",
             "license": "MIT",
             "devDependencies": {
                 "@becklyn/eslint": "*",
@@ -15444,6 +15448,24 @@
             },
             "peerDependencies": {
                 "next": "^14.0.0 || ^15.0.0 || ^16.0.0"
+            }
+        },
+        "packages/deployment-protection-auth-proxy": {
+            "name": "@becklyn/deployment-protection-auth-proxy",
+            "version": "0.1.0",
+            "dependencies": {
+                "@becklyn/deployment-protection": "*",
+                "next": "^16.3.0",
+                "react": "^19.2.8",
+                "react-dom": "^19.2.8"
+            },
+            "devDependencies": {
+                "@becklyn/eslint": "*",
+                "@becklyn/tsconfig": "*",
+                "@types/node": "^25.9.5",
+                "@types/react": "^19.2.18",
+                "@types/react-dom": "^19.2.4",
+                "typescript": "^5.9.3"
             }
         },
         "packages/eslint": {

--- a/packages/deployment-protection-auth-proxy/.gitignore
+++ b/packages/deployment-protection-auth-proxy/.gitignore
@@ -1,0 +1,7 @@
+node_modules
+.next
+.next-*/
+out
+dist
+*.tsbuildinfo
+next-env.d.ts

--- a/packages/deployment-protection-auth-proxy/DECISIONS.md
+++ b/packages/deployment-protection-auth-proxy/DECISIONS.md
@@ -1,0 +1,10 @@
+# Decisions
+
+## Auth proxy instead of per-project OAuth callbacks
+
+- Vercel SSO requires a registered redirect URL per host; preview URLs make that unmaintainable.
+- One small Next.js app owns the single `/callback` and brokers login back to protected apps.
+- Apps call `/start` with an HMAC-signed `return_origin` + `return_path` (not a raw shared secret in the URL).
+- After Vercel OAuth, the proxy returns a short-lived audience-bound handoff token; each app verifies it and sets its own session cookie.
+- Optional `DEPLOYMENT_PROTECTION_ALLOWED_ORIGINS` allowlist on the proxy as defense in depth.
+- Direct (legacy) per-app Vercel OAuth remains supported when `DEPLOYMENT_PROTECTION_AUTH_PROXY_URL` is unset.

--- a/packages/deployment-protection-auth-proxy/README.md
+++ b/packages/deployment-protection-auth-proxy/README.md
@@ -1,0 +1,36 @@
+# Deployment protection auth proxy
+
+Central **Sign in with Vercel** broker for [`@becklyn/deployment-protection`](../deployment-protection).
+
+Register **one** OAuth callback on the Vercel app:
+
+```text
+https://<this-host>/callback
+```
+
+## Env
+
+| Variable                                                                 | Required    | Description                            |
+| ------------------------------------------------------------------------ | ----------- | -------------------------------------- |
+| `DEPLOYMENT_PROTECTION_VERCEL_CLIENT_ID`                                 | yes         | Vercel OAuth client id                 |
+| `DEPLOYMENT_PROTECTION_VERCEL_CLIENT_SECRET`                             | yes         | Vercel OAuth client secret             |
+| `DEPLOYMENT_PROTECTION_SECRET` or `DEPLOYMENT_PROTECTION_HANDOFF_SECRET` | yes         | Shared HMAC secret with protected apps |
+| `DEPLOYMENT_PROTECTION_ALLOWED_ORIGINS`                                  | recommended | Comma-separated origin allowlist       |
+
+Protected apps only need:
+
+```bash
+DEPLOYMENT_PROTECTION_AUTH_PROXY_URL=https://<this-host>
+DEPLOYMENT_PROTECTION_SECRET=<same-or-session-secret>
+DEPLOYMENT_PROTECTION_HANDOFF_SECRET=<same-as-proxy>
+```
+
+## Develop
+
+```bash
+npm run dev -w @becklyn/deployment-protection-auth-proxy
+```
+
+## Deploy
+
+Deploy this package as its own Vercel project. Point the Vercel OAuth app callback at `/callback` on that production host.

--- a/packages/deployment-protection-auth-proxy/app/callback/route.ts
+++ b/packages/deployment-protection-auth-proxy/app/callback/route.ts
@@ -1,0 +1,5 @@
+import { handleAuthProxyCallback } from "@becklyn/deployment-protection";
+
+export function GET(request: Request): Promise<Response> {
+    return handleAuthProxyCallback(request);
+}

--- a/packages/deployment-protection-auth-proxy/app/layout.tsx
+++ b/packages/deployment-protection-auth-proxy/app/layout.tsx
@@ -1,0 +1,14 @@
+import type { ReactElement, ReactNode } from "react";
+
+export const metadata = {
+    title: "Deployment protection auth proxy",
+    robots: { index: false, follow: false },
+};
+
+export default function RootLayout({ children }: { children: ReactNode }): ReactElement {
+    return (
+        <html lang="en">
+            <body style={{ margin: 0 }}>{children}</body>
+        </html>
+    );
+}

--- a/packages/deployment-protection-auth-proxy/app/page.tsx
+++ b/packages/deployment-protection-auth-proxy/app/page.tsx
@@ -1,0 +1,30 @@
+import type { ReactElement } from "react";
+
+export default function HomePage(): ReactElement {
+    return (
+        <main
+            style={{
+                fontFamily: "ui-sans-serif, system-ui, sans-serif",
+                maxWidth: 560,
+                margin: "10vh auto",
+                padding: 24,
+                lineHeight: 1.5,
+            }}>
+            <h1 style={{ fontSize: "1.5rem", marginBottom: 8 }}>
+                Deployment protection auth proxy
+            </h1>
+            <p style={{ color: "#64748b" }}>
+                This service brokers <strong>Sign in with Vercel</strong> for apps using{" "}
+                <code>@becklyn/deployment-protection</code>. It is not meant to be opened directly.
+            </p>
+            <ul>
+                <li>
+                    <code>/start</code> — signed entry from a protected app
+                </li>
+                <li>
+                    <code>/callback</code> — single Vercel OAuth redirect URI
+                </li>
+            </ul>
+        </main>
+    );
+}

--- a/packages/deployment-protection-auth-proxy/app/start/route.ts
+++ b/packages/deployment-protection-auth-proxy/app/start/route.ts
@@ -1,0 +1,5 @@
+import { handleAuthProxyStart } from "@becklyn/deployment-protection";
+
+export function GET(request: Request): Promise<Response> {
+    return handleAuthProxyStart(request);
+}

--- a/packages/deployment-protection-auth-proxy/eslint.config.mjs
+++ b/packages/deployment-protection-auth-proxy/eslint.config.mjs
@@ -1,0 +1,4 @@
+import { nextJsConfig } from "@becklyn/eslint/next-js";
+
+/** @type {import("eslint").Linter.Config} */
+export default [...nextJsConfig];

--- a/packages/deployment-protection-auth-proxy/next.config.ts
+++ b/packages/deployment-protection-auth-proxy/next.config.ts
@@ -1,0 +1,7 @@
+import type { NextConfig } from "next";
+
+const nextConfig: NextConfig = {
+    reactStrictMode: true,
+};
+
+export default nextConfig;

--- a/packages/deployment-protection-auth-proxy/package.json
+++ b/packages/deployment-protection-auth-proxy/package.json
@@ -1,0 +1,28 @@
+{
+    "name": "@becklyn/deployment-protection-auth-proxy",
+    "version": "0.1.0",
+    "private": true,
+    "description": "Central Sign in with Vercel auth-proxy for @becklyn/deployment-protection",
+    "scripts": {
+        "dev": "next dev --port 3010",
+        "build": "next build",
+        "start": "next start --port 3010",
+        "lint": "eslint . --max-warnings 0 && prettier --check \"./**/*.{ts,tsx,md,json}\"",
+        "fix": "eslint . --fix && prettier --write \"./**/*.{ts,tsx,md,json}\""
+    },
+    "dependencies": {
+        "@becklyn/deployment-protection": "*",
+        "next": "^16.3.0",
+        "react": "^19.2.8",
+        "react-dom": "^19.2.8"
+    },
+    "devDependencies": {
+        "@becklyn/eslint": "*",
+        "@becklyn/tsconfig": "*",
+        "@types/node": "^25.9.5",
+        "@types/react": "^19.2.18",
+        "@types/react-dom": "^19.2.4",
+        "typescript": "^5.9.3"
+    },
+    "prettier": "@becklyn/prettier"
+}

--- a/packages/deployment-protection-auth-proxy/tsconfig.json
+++ b/packages/deployment-protection-auth-proxy/tsconfig.json
@@ -1,0 +1,16 @@
+{
+    "extends": "@becklyn/tsconfig/nextjs.json",
+    "compilerOptions": {
+        "plugins": [
+            {
+                "name": "next"
+            }
+        ],
+        "baseUrl": ".",
+        "paths": {
+            "@/*": ["./*"]
+        }
+    },
+    "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+    "exclude": ["node_modules"]
+}

--- a/packages/deployment-protection/README.md
+++ b/packages/deployment-protection/README.md
@@ -70,33 +70,97 @@ export default withDeploymentProtection(async request => {
 | `DEPLOYMENT_PROTECTION_ENABLED`              | no                | `true`                    | Set `false` / `0` / `off` to disable                   |
 | `DEPLOYMENT_PROTECTION_USERNAME`             | for password auth | —                         | Shared username                                        |
 | `DEPLOYMENT_PROTECTION_PASSWORD`             | for password auth | —                         | Shared password                                        |
-| `DEPLOYMENT_PROTECTION_SECRET`               | recommended       | derived from user+pass    | HMAC secret for session cookies                        |
+| `DEPLOYMENT_PROTECTION_SECRET`               | recommended       | derived from user+pass    | HMAC secret for session cookies (+ handoff fallback)   |
+| `DEPLOYMENT_PROTECTION_AUTH_PROXY_URL`       | for proxy SSO     | —                         | Base URL of the central auth-proxy app                 |
+| `DEPLOYMENT_PROTECTION_HANDOFF_SECRET`       | no                | same as `…_SECRET`        | Shared secret between apps and the auth-proxy          |
 | `VERCEL_AUTOMATION_BYPASS_SECRET`            | no                | —                         | Same secret as Vercel Protection Bypass for Automation |
-| `DEPLOYMENT_PROTECTION_VERCEL_CLIENT_ID`     | for Vercel login  | —                         | Or `NEXT_PUBLIC_VERCEL_APP_CLIENT_ID`                  |
-| `DEPLOYMENT_PROTECTION_VERCEL_CLIENT_SECRET` | for Vercel login  | —                         | Or `VERCEL_APP_CLIENT_SECRET`                          |
+| `DEPLOYMENT_PROTECTION_VERCEL_CLIENT_ID`     | direct Vercel SSO | —                         | Or `NEXT_PUBLIC_VERCEL_APP_CLIENT_ID` (legacy)         |
+| `DEPLOYMENT_PROTECTION_VERCEL_CLIENT_SECRET` | direct Vercel SSO | —                         | Or `VERCEL_APP_CLIENT_SECRET` (legacy)                 |
 | `DEPLOYMENT_PROTECTION_FORM_TITLE`           | no                | `Authentication required` | Login heading                                          |
 | `DEPLOYMENT_PROTECTION_FORM_DESCRIPTION`     | no                | …                         | Login description                                      |
 
-At least one of password auth, Vercel OAuth, or a bypass secret must be configured while enabled. If nothing is configured, the gate stays inactive (fail-open) so local dev is not bricked.
+At least one of password auth, Vercel OAuth (proxy or direct), or a bypass secret must be configured while enabled. If nothing is configured, the gate stays inactive (fail-open) so local dev is not bricked.
 
-### 3. Sign in with Vercel (optional)
+### 3. Sign in with Vercel via auth-proxy (recommended)
 
-1. Create a [Sign in with Vercel](https://vercel.com/docs/sign-in-with-vercel) app in the Vercel dashboard.
-2. Generate a client secret.
-3. Add authorization callback URLs for each project host, pointing at:
+Register **one** OAuth callback URL on a shared [Sign in with Vercel](https://vercel.com/docs/sign-in-with-vercel) app:
+
+```text
+https://<auth-proxy-host>/callback
+```
+
+Deploy the `deployment-protection-auth-proxy` app from this monorepo (or any tiny Next app that wires the handlers below) and set:
+
+**On the auth-proxy**
+
+| Variable                                             | Description                            |
+| ---------------------------------------------------- | -------------------------------------- |
+| `DEPLOYMENT_PROTECTION_VERCEL_CLIENT_ID`             | Vercel OAuth client id                 |
+| `DEPLOYMENT_PROTECTION_VERCEL_CLIENT_SECRET`         | Vercel OAuth client secret             |
+| `DEPLOYMENT_PROTECTION_SECRET` or `…_HANDOFF_SECRET` | Shared HMAC secret with protected apps |
+| `DEPLOYMENT_PROTECTION_ALLOWED_ORIGINS`              | Optional allowlist (see below)         |
+
+**On every protected app**
+
+| Variable                               | Description                            |
+| -------------------------------------- | -------------------------------------- |
+| `DEPLOYMENT_PROTECTION_AUTH_PROXY_URL` | e.g. `https://dp-auth.example.com`     |
+| `DEPLOYMENT_PROTECTION_SECRET`         | Session cookie secret                  |
+| `DEPLOYMENT_PROTECTION_HANDOFF_SECRET` | Same as proxy (defaults to `…_SECRET`) |
+
+No per-project / per-preview callback URLs.
+
+#### Flow
+
+1. App redirects to `{AUTH_PROXY_URL}/start` with a **signed** `return_origin` + `return_path`.
+2. Proxy runs Vercel OAuth against its fixed `/callback`.
+3. Proxy redirects to  
+   `{return_origin}/_becklyn/deployment-protection/vercel/callback?handoff=…&return_to=…`
+4. App verifies the short-lived handoff token (`aud` must match its origin), sets `__becklyn_dp_session`, continues.
+
+#### Allowlist (proxy)
+
+`DEPLOYMENT_PROTECTION_ALLOWED_ORIGINS` is a comma-separated list:
+
+- full origins: `https://app.example.com`
+- host suffixes: `.vercel.app`, `example.com`
+- `localhost` (http(s) localhost / 127.0.0.1)
+
+Empty allowlist → any origin that passes https (or local http) validation. Prefer an allowlist in production.
+
+#### Minimal proxy route handlers
+
+```ts
+// app/start/route.ts
+import { handleAuthProxyStart } from "@becklyn/deployment-protection";
+
+export const GET = (request: Request) => handleAuthProxyStart(request);
+
+// app/callback/route.ts
+import { handleAuthProxyCallback } from "@becklyn/deployment-protection";
+
+export const GET = (request: Request) => handleAuthProxyCallback(request);
+```
+
+### 4. Sign in with Vercel (legacy direct mode)
+
+Still supported when `DEPLOYMENT_PROTECTION_AUTH_PROXY_URL` is unset:
+
+1. Create a Sign in with Vercel app.
+2. Add authorization callback URLs for **each** project host:
 
     ```text
     https://<your-host>/_becklyn/deployment-protection/vercel/callback
     http://localhost:3000/_becklyn/deployment-protection/vercel/callback
     ```
 
-    You can attach the path to preview + production domains of each project from the dashboard.
+3. Set client id/secret on the project(s).
 
-4. Set client id/secret env vars on the project(s). Prefer team-level shared env values.
+When both proxy URL and direct client credentials are set, **proxy mode wins** for the authorize step.
 
 Scopes used: `openid email profile`.
 
-### 4. Automation bypass
+### 5. Automation bypass
 
 Matches Vercel’s Protection Bypass for Automation:
 
@@ -116,7 +180,7 @@ When platform Deployment Protection is disabled, **this package** enforces the b
 ## Behaviour
 
 1. Disabled / misconfigured → pass through
-2. Internal Vercel OAuth routes → handled by the package
+2. Internal Vercel OAuth routes → handled by the package (proxy start or direct OAuth / handoff)
 3. Login form `POST` → validate username/password, set signed HttpOnly session cookie
 4. Valid bypass header/query/cookie → allow (optionally set cookies)
 5. Valid session cookie → allow
@@ -136,6 +200,8 @@ Redeploy. Middleware stays installed but is a no-op.
 
 ```ts
 import {
+    handleAuthProxyCallback,
+    handleAuthProxyStart,
     handleDeploymentProtection,
     resolveConfig,
     withDeploymentProtection,
@@ -144,6 +210,7 @@ import {
 
 - `withDeploymentProtection(options?)` / `withDeploymentProtection(next, options?)` — middleware/proxy factory
 - `handleDeploymentProtection(request, options?)` — framework-agnostic core (`null` = continue)
+- `handleAuthProxyStart` / `handleAuthProxyCallback` — central auth-proxy routes
 
 Recommended matcher (must be pasted as a string literal in your middleware/proxy file — see above):
 
@@ -155,6 +222,8 @@ Recommended matcher (must be pasted as a string literal in your middleware/proxy
 
 - This is a **shared-secret gate**, not per-user product auth.
 - Prefer a dedicated `DEPLOYMENT_PROTECTION_SECRET` in production.
+- Auth-proxy start requests are HMAC-signed; handoff tokens are short-lived and audience-bound.
+- Do not put the raw handoff secret in query strings — only signatures/tokens.
 - Turn off paid Vercel Password Protection / seat-heavy sharing once this is live; keep `VERCEL_AUTOMATION_BYPASS_SECRET` configured for tooling.
 - Middleware is a convenience edge check — do not treat it as the only control for highly sensitive data.
 

--- a/packages/deployment-protection/src/auth-proxy.test.ts
+++ b/packages/deployment-protection/src/auth-proxy.test.ts
@@ -1,0 +1,156 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { handleAuthProxyCallback, handleAuthProxyStart } from "./auth-proxy";
+import {
+    OAUTH_RETURN_COOKIE,
+    OAUTH_RETURN_ORIGIN_COOKIE,
+    OAUTH_STATE_COOKIE,
+    OAUTH_VERIFIER_COOKIE,
+    VERCEL_CALLBACK_PATH,
+} from "./constants";
+import { buildProxyStartUrl, verifyHandoffToken } from "./handoff";
+
+const proxyEnv = {
+    DEPLOYMENT_PROTECTION_SECRET: "shared-handoff-secret",
+    DEPLOYMENT_PROTECTION_VERCEL_CLIENT_ID: "client",
+    DEPLOYMENT_PROTECTION_VERCEL_CLIENT_SECRET: "client-secret",
+};
+
+function readSetCookies(response: Response): string[] {
+    if (typeof response.headers.getSetCookie === "function") {
+        return response.headers.getSetCookie();
+    }
+
+    const single = response.headers.get("Set-Cookie");
+    return single ? [single] : [];
+}
+
+function cookieHeaderFromResponse(response: Response): string {
+    return readSetCookies(response)
+        .map(part => part.split(";")[0]!)
+        .join("; ");
+}
+
+describe("handleAuthProxyStart", () => {
+    it("rejects unsigned start requests", async () => {
+        const response = await handleAuthProxyStart(
+            new Request(
+                "https://dp-auth.example.com/start?return_origin=https://app.example.com&return_path=/&exp=9999999999&nonce=n&sig=bad"
+            ),
+            { env: proxyEnv }
+        );
+        expect(response.status).toBe(403);
+    });
+
+    it("redirects to Vercel authorize for a valid signed start", async () => {
+        const startUrl = await buildProxyStartUrl({
+            authProxyUrl: "https://dp-auth.example.com",
+            secret: proxyEnv.DEPLOYMENT_PROTECTION_SECRET,
+            returnOrigin: "https://app.example.com",
+            returnPath: "/dashboard",
+        });
+
+        const response = await handleAuthProxyStart(new Request(startUrl), { env: proxyEnv });
+        expect(response.status).toBe(302);
+        const location = response.headers.get("Location");
+        expect(location).toContain("https://vercel.com/oauth/authorize?");
+        expect(location).toContain(encodeURIComponent("https://dp-auth.example.com/callback"));
+        const cookies = readSetCookies(response).join("\n");
+        expect(cookies).toContain(OAUTH_RETURN_ORIGIN_COOKIE);
+        expect(cookies).toContain(OAUTH_STATE_COOKIE);
+    });
+
+    it("enforces allowlist", async () => {
+        const startUrl = await buildProxyStartUrl({
+            authProxyUrl: "https://dp-auth.example.com",
+            secret: proxyEnv.DEPLOYMENT_PROTECTION_SECRET,
+            returnOrigin: "https://evil.com",
+            returnPath: "/",
+        });
+
+        const response = await handleAuthProxyStart(new Request(startUrl), {
+            env: {
+                ...proxyEnv,
+                DEPLOYMENT_PROTECTION_ALLOWED_ORIGINS: ".vercel.app,https://app.example.com",
+            },
+        });
+        expect(response.status).toBe(403);
+        expect(await response.text()).toContain("not allowed");
+    });
+});
+
+describe("handleAuthProxyCallback", () => {
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    it("mints a handoff token and redirects to the app callback", async () => {
+        vi.stubGlobal(
+            "fetch",
+            vi.fn(async (input: RequestInfo | URL) => {
+                const url = String(input);
+
+                if (url.includes("/login/oauth/token")) {
+                    return new Response(
+                        JSON.stringify({
+                            access_token: "access",
+                            token_type: "Bearer",
+                            expires_in: 3600,
+                        }),
+                        { status: 200, headers: { "Content-Type": "application/json" } }
+                    );
+                }
+
+                if (url.includes("/login/oauth/userinfo")) {
+                    return new Response(JSON.stringify({ preferred_username: "alice" }), {
+                        status: 200,
+                        headers: { "Content-Type": "application/json" },
+                    });
+                }
+
+                throw new Error(`Unexpected fetch: ${url}`);
+            })
+        );
+
+        const startUrl = await buildProxyStartUrl({
+            authProxyUrl: "https://dp-auth.example.com",
+            secret: proxyEnv.DEPLOYMENT_PROTECTION_SECRET,
+            returnOrigin: "https://app.example.com",
+            returnPath: "/after",
+        });
+        const startResponse = await handleAuthProxyStart(new Request(startUrl), { env: proxyEnv });
+        const cookies = cookieHeaderFromResponse(startResponse);
+        const state = cookies
+            .split("; ")
+            .map(part => part.trim())
+            .find(part => part.startsWith(`${OAUTH_STATE_COOKIE}=`))
+            ?.split("=")[1];
+
+        expect(state).toBeTruthy();
+        expect(cookies).toContain(OAUTH_VERIFIER_COOKIE);
+        expect(cookies).toContain(OAUTH_RETURN_COOKIE);
+
+        const callbackResponse = await handleAuthProxyCallback(
+            new Request(
+                `https://dp-auth.example.com/callback?code=auth-code&state=${decodeURIComponent(state!)}`,
+                {
+                    headers: { cookie: cookies },
+                }
+            ),
+            { env: proxyEnv }
+        );
+
+        expect(callbackResponse.status).toBe(302);
+        const location = new URL(callbackResponse.headers.get("Location")!);
+        expect(location.origin).toBe("https://app.example.com");
+        expect(location.pathname).toBe(VERCEL_CALLBACK_PATH);
+        expect(location.searchParams.get("return_to")).toBe("/after");
+
+        const handoff = location.searchParams.get("handoff");
+        const payload = await verifyHandoffToken(
+            proxyEnv.DEPLOYMENT_PROTECTION_SECRET,
+            handoff,
+            "https://app.example.com"
+        );
+        expect(payload?.subject).toBe("alice");
+    });
+});

--- a/packages/deployment-protection/src/auth-proxy.ts
+++ b/packages/deployment-protection/src/auth-proxy.ts
@@ -1,0 +1,183 @@
+import { hasVercelDirectAuth, resolveConfig } from "./config";
+import {
+    OAUTH_NONCE_COOKIE,
+    OAUTH_RETURN_COOKIE,
+    OAUTH_RETURN_ORIGIN_COOKIE,
+    OAUTH_VERIFIER_COOKIE,
+    VERCEL_CALLBACK_PATH,
+} from "./constants";
+import { timingSafeEqualString } from "./crypto";
+import {
+    type ProxyStartParams,
+    createHandoffToken,
+    isReturnOriginAllowed,
+    normalizeReturnOrigin,
+    verifyProxyStartSignature,
+} from "./handoff";
+import { safeReturnTo } from "./safe-return-to";
+import type { DeploymentProtectionOptions } from "./types";
+import {
+    appendSetCookie,
+    assertOAuthState,
+    buildVercelAuthorizeRedirect,
+    clearOAuthCookies,
+    decodeIdTokenNonce,
+    exchangeVercelCode,
+    fetchVercelUserInfo,
+    readCookie,
+} from "./vercel-oauth";
+
+/** Fixed OAuth callback path registered once on the Vercel OAuth app. */
+export const AUTH_PROXY_CALLBACK_PATH = "/callback";
+export const AUTH_PROXY_START_PATH = "/start";
+
+function isSecureRequest(request: Request): boolean {
+    return new URL(request.url).protocol === "https:";
+}
+
+function textResponse(message: string, status: number): Response {
+    return new Response(message, {
+        status,
+        headers: {
+            "Content-Type": "text/plain; charset=utf-8",
+            "Cache-Control": "no-store",
+        },
+    });
+}
+
+function cookieOptions(secure: boolean) {
+    return {
+        httpOnly: true,
+        sameSite: "lax" as const,
+        secure,
+        path: "/",
+        maxAge: 10 * 60,
+    };
+}
+
+/**
+ * Auth-proxy entry: verify the signed start request from a protected app, then
+ * begin Sign in with Vercel against this proxy's fixed callback URL.
+ */
+export async function handleAuthProxyStart(
+    request: Request,
+    options: DeploymentProtectionOptions = {}
+): Promise<Response> {
+    const config = resolveConfig(options);
+
+    if (!hasVercelDirectAuth(config) || !config.handoffSecret) {
+        return textResponse("Auth proxy is not configured", 500);
+    }
+
+    const url = new URL(request.url);
+    const returnOrigin = normalizeReturnOrigin(url.searchParams.get("return_origin"));
+    const returnPath = safeReturnTo(url.searchParams.get("return_path"));
+    const expRaw = url.searchParams.get("exp");
+    const nonce = url.searchParams.get("nonce");
+    const sig = url.searchParams.get("sig");
+    const exp = expRaw ? Number(expRaw) : NaN;
+
+    if (!returnOrigin || !nonce || !Number.isFinite(exp)) {
+        return textResponse("Invalid start request", 400);
+    }
+
+    if (!isReturnOriginAllowed(returnOrigin, config.allowedReturnOrigins)) {
+        return textResponse("Return origin is not allowed", 403);
+    }
+
+    const params: ProxyStartParams = {
+        returnOrigin,
+        returnPath,
+        exp,
+        nonce,
+    };
+
+    if (!(await verifyProxyStartSignature(config.handoffSecret, params, sig))) {
+        return textResponse("Invalid or expired start signature", 403);
+    }
+
+    const response = await buildVercelAuthorizeRedirect(request, config, returnPath, {
+        callbackPath: AUTH_PROXY_CALLBACK_PATH,
+    });
+    const secure = isSecureRequest(request);
+    appendSetCookie(response, OAUTH_RETURN_ORIGIN_COOKIE, returnOrigin, cookieOptions(secure));
+    return response;
+}
+
+/**
+ * Auth-proxy Vercel OAuth callback: exchange the code, mint a short-lived handoff
+ * token, and redirect back to the protected app callback.
+ */
+export async function handleAuthProxyCallback(
+    request: Request,
+    options: DeploymentProtectionOptions = {}
+): Promise<Response> {
+    const config = resolveConfig(options);
+
+    if (!hasVercelDirectAuth(config) || !config.handoffSecret) {
+        return textResponse("Auth proxy is not configured", 500);
+    }
+
+    const url = new URL(request.url);
+    const code = url.searchParams.get("code");
+    const state = url.searchParams.get("state");
+    const secure = isSecureRequest(request);
+    const returnOrigin = normalizeReturnOrigin(readCookie(request, OAUTH_RETURN_ORIGIN_COOKIE));
+    const returnPath = safeReturnTo(readCookie(request, OAUTH_RETURN_COOKIE));
+
+    const fail = (message: string, status = 401): Response => {
+        const response = textResponse(message, status);
+        clearOAuthCookies(response, secure);
+        return response;
+    };
+
+    if (!returnOrigin) {
+        return fail("Missing return origin", 400);
+    }
+
+    if (!isReturnOriginAllowed(returnOrigin, config.allowedReturnOrigins)) {
+        return fail("Return origin is not allowed", 403);
+    }
+
+    if (!code || !(await assertOAuthState(request, state))) {
+        return fail("Vercel sign-in failed (invalid state)");
+    }
+
+    try {
+        const codeVerifier = readCookie(request, OAUTH_VERIFIER_COOKIE);
+
+        if (!codeVerifier) {
+            throw new Error("Missing PKCE verifier");
+        }
+
+        const tokenData = await exchangeVercelCode(request, config, code, codeVerifier, {
+            callbackPath: AUTH_PROXY_CALLBACK_PATH,
+        });
+        const storedNonce = readCookie(request, OAUTH_NONCE_COOKIE);
+        const tokenNonce = decodeIdTokenNonce(tokenData.id_token);
+
+        if (storedNonce && tokenNonce && !(await timingSafeEqualString(storedNonce, tokenNonce))) {
+            throw new Error("Nonce mismatch");
+        }
+
+        const user = await fetchVercelUserInfo(tokenData.access_token);
+        const subject = user.preferred_username || user.email || user.sub || "vercel-user";
+        const handoff = await createHandoffToken(config.handoffSecret, returnOrigin, subject);
+
+        const target = new URL(VERCEL_CALLBACK_PATH, `${returnOrigin}/`);
+        target.searchParams.set("handoff", handoff);
+        target.searchParams.set("return_to", returnPath);
+
+        const response = new Response(null, {
+            status: 302,
+            headers: {
+                Location: target.toString(),
+                "Cache-Control": "no-store",
+            },
+        });
+        clearOAuthCookies(response, secure);
+        return response;
+    } catch {
+        return fail("Vercel sign-in failed");
+    }
+}

--- a/packages/deployment-protection/src/config.ts
+++ b/packages/deployment-protection/src/config.ts
@@ -1,3 +1,4 @@
+import { parseAllowlist } from "./handoff";
 import type { DeploymentProtectionConfig, DeploymentProtectionOptions, EnvMap } from "./types";
 
 const FALSEY = new Set(["0", "false", "no", "off"]);
@@ -42,16 +43,29 @@ export function resolveConfig(
     // Prefer an explicit secret; otherwise derive a stable key from credentials so
     // projects can stay zero-config beyond username/password.
     const secret = explicitSecret ?? (username && password ? `dp:${username}:${password}` : null);
+    const handoffSecret =
+        read(env, "DEPLOYMENT_PROTECTION_HANDOFF_SECRET") ?? explicitSecret ?? secret;
+    const authProxyUrl =
+        read(env, "DEPLOYMENT_PROTECTION_AUTH_PROXY_URL")?.replace(/\/$/, "") ?? null;
 
     return {
         enabled: isEnabled(env),
         username,
         password,
         secret,
+        handoffSecret,
         bypassSecret: read(
             env,
             "VERCEL_AUTOMATION_BYPASS_SECRET",
             "DEPLOYMENT_PROTECTION_BYPASS_SECRET"
+        ),
+        authProxyUrl,
+        allowedReturnOrigins: parseAllowlist(
+            read(
+                env,
+                "DEPLOYMENT_PROTECTION_ALLOWED_ORIGINS",
+                "DEPLOYMENT_PROTECTION_AUTH_PROXY_ALLOWED_ORIGINS"
+            )
         ),
         vercelClientId: read(
             env,
@@ -80,8 +94,21 @@ export function hasPasswordAuth(config: DeploymentProtectionConfig): boolean {
     return Boolean(config.username && config.password && config.secret);
 }
 
-export function hasVercelAuth(config: DeploymentProtectionConfig): boolean {
+/** Direct Vercel OAuth on the protected app (legacy / single-project setup). */
+export function hasVercelDirectAuth(config: DeploymentProtectionConfig): boolean {
     return Boolean(config.vercelClientId && config.vercelClientSecret && config.secret);
+}
+
+/**
+ * Central auth-proxy mode: apps only need the proxy URL + shared handoff secret.
+ * Vercel client credentials live solely on the proxy.
+ */
+export function hasVercelProxyAuth(config: DeploymentProtectionConfig): boolean {
+    return Boolean(config.authProxyUrl && config.handoffSecret && config.secret);
+}
+
+export function hasVercelAuth(config: DeploymentProtectionConfig): boolean {
+    return hasVercelDirectAuth(config) || hasVercelProxyAuth(config);
 }
 
 /**

--- a/packages/deployment-protection/src/constants.ts
+++ b/packages/deployment-protection/src/constants.ts
@@ -4,6 +4,7 @@ export const OAUTH_STATE_COOKIE = "__becklyn_dp_oauth_state";
 export const OAUTH_NONCE_COOKIE = "__becklyn_dp_oauth_nonce";
 export const OAUTH_VERIFIER_COOKIE = "__becklyn_dp_oauth_verifier";
 export const OAUTH_RETURN_COOKIE = "__becklyn_dp_oauth_return";
+export const OAUTH_RETURN_ORIGIN_COOKIE = "__becklyn_dp_oauth_return_origin";
 
 export const INTERNAL_PATH_PREFIX = "/_becklyn/deployment-protection";
 export const VERCEL_AUTHORIZE_PATH = `${INTERNAL_PATH_PREFIX}/vercel`;

--- a/packages/deployment-protection/src/handler.test.ts
+++ b/packages/deployment-protection/src/handler.test.ts
@@ -224,3 +224,74 @@ describe("handleDeploymentProtection", () => {
         expect(await response!.text()).toContain("Sign in with Vercel");
     });
 });
+
+describe("auth proxy mode on protected apps", () => {
+    it("detects proxy auth without vercel client credentials", () => {
+        const config = resolveConfig({
+            env: {
+                DEPLOYMENT_PROTECTION_SECRET: "super-long-signing-secret",
+                DEPLOYMENT_PROTECTION_AUTH_PROXY_URL: "https://dp-auth.example.com",
+            },
+        });
+        expect(hasVercelAuth(config)).toBe(true);
+        expect(config.authProxyUrl).toBe("https://dp-auth.example.com");
+    });
+
+    it("redirects authorize to the auth proxy with a signature", async () => {
+        const response = await handleDeploymentProtection(
+            new Request(
+                "https://app.example.com/_becklyn/deployment-protection/vercel?return_to=/dash"
+            ),
+            {
+                env: {
+                    DEPLOYMENT_PROTECTION_SECRET: "super-long-signing-secret",
+                    DEPLOYMENT_PROTECTION_AUTH_PROXY_URL: "https://dp-auth.example.com",
+                },
+            }
+        );
+        expect(response).not.toBeNull();
+        expect(response!.status).toBe(302);
+        const location = new URL(response!.headers.get("Location")!);
+        expect(location.origin).toBe("https://dp-auth.example.com");
+        expect(location.pathname).toBe("/start");
+        expect(location.searchParams.get("return_origin")).toBe("https://app.example.com");
+        expect(location.searchParams.get("return_path")).toBe("/dash");
+        expect(location.searchParams.get("sig")).toBeTruthy();
+    });
+
+    it("accepts a valid handoff token on the app callback", async () => {
+        const { createHandoffToken } = await import("./handoff");
+        const handoff = await createHandoffToken(
+            "super-long-signing-secret",
+            "https://app.example.com",
+            "alice",
+            60
+        );
+        const response = await handleDeploymentProtection(
+            new Request(
+                `https://app.example.com/_becklyn/deployment-protection/vercel/callback?handoff=${encodeURIComponent(handoff)}&return_to=/home`
+            ),
+            {
+                env: {
+                    DEPLOYMENT_PROTECTION_SECRET: "super-long-signing-secret",
+                    DEPLOYMENT_PROTECTION_AUTH_PROXY_URL: "https://dp-auth.example.com",
+                },
+            }
+        );
+        expect(response).not.toBeNull();
+        expect(response!.status).toBe(302);
+        expect(response!.headers.get("Location")).toBe("https://app.example.com/home");
+        expect(response!.headers.get("Set-Cookie")).toContain(SESSION_COOKIE_NAME);
+    });
+
+    it("shows Sign in with Vercel when only auth proxy is configured", async () => {
+        const response = await handleDeploymentProtection(new Request("https://example.com/"), {
+            env: {
+                DEPLOYMENT_PROTECTION_SECRET: "super-long-signing-secret",
+                DEPLOYMENT_PROTECTION_AUTH_PROXY_URL: "https://dp-auth.example.com",
+            },
+        });
+        expect(response).not.toBeNull();
+        expect(await response!.text()).toContain("Sign in with Vercel");
+    });
+});

--- a/packages/deployment-protection/src/handler.ts
+++ b/packages/deployment-protection/src/handler.ts
@@ -1,5 +1,12 @@
 import { isValidBypass, readBypassCookie, readBypassToken, shouldSetBypassCookie } from "./bypass";
-import { hasPasswordAuth, hasVercelAuth, isProtectionActive, resolveConfig } from "./config";
+import {
+    hasPasswordAuth,
+    hasVercelAuth,
+    hasVercelDirectAuth,
+    hasVercelProxyAuth,
+    isProtectionActive,
+    resolveConfig,
+} from "./config";
 import {
     BYPASS_COOKIE_NAME,
     BYPASS_HEADER,
@@ -11,6 +18,7 @@ import {
     VERCEL_CALLBACK_PATH,
 } from "./constants";
 import { timingSafeEqualString } from "./crypto";
+import { buildProxyStartUrl, verifyHandoffToken } from "./handoff";
 import { renderLoginPage } from "./login-page";
 import { validatePasswordCredentials } from "./password";
 import { safeReturnTo } from "./safe-return-to";
@@ -184,6 +192,22 @@ async function handleVercelAuthorize(
     }
 
     const returnTo = safeReturnTo(new URL(request.url).searchParams.get("return_to"));
+
+    // Prefer central auth-proxy so apps never register per-host OAuth callbacks.
+    if (hasVercelProxyAuth(config) && config.authProxyUrl && config.handoffSecret) {
+        const startUrl = await buildProxyStartUrl({
+            authProxyUrl: config.authProxyUrl,
+            secret: config.handoffSecret,
+            returnOrigin: new URL(request.url).origin,
+            returnPath: returnTo,
+        });
+        return redirect(request, startUrl);
+    }
+
+    if (!hasVercelDirectAuth(config)) {
+        return new Response("Sign in with Vercel is not configured", { status: 500 });
+    }
+
     return buildVercelAuthorizeRedirect(request, config, returnTo);
 }
 
@@ -200,9 +224,40 @@ async function handleVercelCallback(
     }
 
     const url = new URL(request.url);
+    const handoff = url.searchParams.get("handoff");
+    const secure = isSecureRequest(request);
+
+    // Auth-proxy handoff: short-lived signed token, no Vercel client secret on the app.
+    if (handoff) {
+        if (!config.handoffSecret) {
+            return new Response("Sign in with Vercel is not configured", { status: 500 });
+        }
+
+        const returnTo = safeReturnTo(url.searchParams.get("return_to"));
+        const payload = await verifyHandoffToken(config.handoffSecret, handoff, url.origin);
+
+        if (!payload) {
+            return htmlResponse(
+                renderLoginPage(config, {
+                    error: "Vercel sign-in failed (invalid handoff).",
+                    returnTo,
+                    showPassword: hasPasswordAuth(config),
+                    showVercel: true,
+                })
+            );
+        }
+
+        const response = redirect(request, returnTo);
+        return attachSession(response, config, "vercel", payload.subject, secure);
+    }
+
+    // Legacy direct OAuth callback on the protected app.
+    if (!hasVercelDirectAuth(config)) {
+        return new Response("Sign in with Vercel is not configured", { status: 500 });
+    }
+
     const code = url.searchParams.get("code");
     const state = url.searchParams.get("state");
-    const secure = isSecureRequest(request);
     const returnTo = safeReturnTo(readCookie(request, OAUTH_RETURN_COOKIE));
 
     if (!code || !(await assertOAuthState(request, state))) {

--- a/packages/deployment-protection/src/handoff.test.ts
+++ b/packages/deployment-protection/src/handoff.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+import {
+    buildProxyStartUrl,
+    createHandoffToken,
+    isReturnOriginAllowed,
+    normalizeReturnOrigin,
+    parseAllowlist,
+    signProxyStart,
+    verifyHandoffToken,
+    verifyProxyStartSignature,
+} from "./handoff";
+
+describe("handoff tokens", () => {
+    it("round-trips a signed handoff for the expected audience", async () => {
+        const token = await createHandoffToken("secret", "https://app.example.com", "alice", 60);
+        const payload = await verifyHandoffToken("secret", token, "https://app.example.com");
+        expect(payload?.subject).toBe("alice");
+        expect(payload?.method).toBe("vercel");
+        expect(payload?.aud).toBe("https://app.example.com");
+    });
+
+    it("rejects handoff tokens for a different audience", async () => {
+        const token = await createHandoffToken("secret", "https://app.example.com", "alice", 60);
+        expect(await verifyHandoffToken("secret", token, "https://other.example.com")).toBeNull();
+    });
+
+    it("rejects tampered handoff tokens", async () => {
+        const token = await createHandoffToken("secret", "https://app.example.com", "alice", 60);
+        const tampered = token.replace(".", ".x");
+        expect(await verifyHandoffToken("secret", tampered, "https://app.example.com")).toBeNull();
+    });
+});
+
+describe("proxy start signatures", () => {
+    it("accepts a valid signed start request", async () => {
+        const params = {
+            returnOrigin: "https://preview.example.com",
+            returnPath: "/dashboard",
+            exp: Math.floor(Date.now() / 1000) + 300,
+            nonce: "abc",
+        };
+        const sig = await signProxyStart("secret", params);
+        expect(await verifyProxyStartSignature("secret", params, sig)).toBe(true);
+    });
+
+    it("rejects expired start requests", async () => {
+        const params = {
+            returnOrigin: "https://preview.example.com",
+            returnPath: "/",
+            exp: Math.floor(Date.now() / 1000) - 10,
+            nonce: "abc",
+        };
+        const sig = await signProxyStart("secret", params);
+        expect(await verifyProxyStartSignature("secret", params, sig)).toBe(false);
+    });
+
+    it("builds a start URL with signature params", async () => {
+        const url = new URL(
+            await buildProxyStartUrl({
+                authProxyUrl: "https://dp-auth.example.com",
+                secret: "secret",
+                returnOrigin: "https://app.example.com",
+                returnPath: "/x",
+            })
+        );
+        expect(url.origin).toBe("https://dp-auth.example.com");
+        expect(url.pathname).toBe("/start");
+        expect(url.searchParams.get("return_origin")).toBe("https://app.example.com");
+        expect(url.searchParams.get("return_path")).toBe("/x");
+        expect(url.searchParams.get("sig")).toBeTruthy();
+        expect(url.searchParams.get("nonce")).toBeTruthy();
+    });
+});
+
+describe("return origin validation", () => {
+    it("normalizes https origins and rejects non-https remote origins", () => {
+        expect(normalizeReturnOrigin("https://app.example.com/path")).toBe(
+            "https://app.example.com"
+        );
+        expect(normalizeReturnOrigin("http://evil.com")).toBeNull();
+        expect(normalizeReturnOrigin("http://localhost:3000")).toBe("http://localhost:3000");
+    });
+
+    it("applies allowlist entries", () => {
+        const allowlist = parseAllowlist("https://app.example.com, .vercel.app, localhost");
+        expect(isReturnOriginAllowed("https://app.example.com", allowlist)).toBe(true);
+        expect(isReturnOriginAllowed("https://foo.vercel.app", allowlist)).toBe(true);
+        expect(isReturnOriginAllowed("http://localhost:3000", allowlist)).toBe(true);
+        expect(isReturnOriginAllowed("https://evil.com", allowlist)).toBe(false);
+    });
+});

--- a/packages/deployment-protection/src/handoff.ts
+++ b/packages/deployment-protection/src/handoff.ts
@@ -1,0 +1,266 @@
+import {
+    base64UrlToBytes,
+    bytesToBase64Url,
+    hmacSign,
+    randomToken,
+    timingSafeEqualString,
+} from "./crypto";
+import { safeReturnTo } from "./safe-return-to";
+
+export const HANDOFF_TTL_SECONDS = 60;
+export const PROXY_START_TTL_SECONDS = 5 * 60;
+
+export interface ProxyStartParams {
+    returnOrigin: string;
+    returnPath: string;
+    exp: number;
+    nonce: string;
+}
+
+export interface HandoffPayload {
+    exp: number;
+    aud: string;
+    subject: string;
+    method: "vercel";
+}
+
+function encodeJson(value: unknown): string {
+    return bytesToBase64Url(new TextEncoder().encode(JSON.stringify(value)));
+}
+
+function decodeJson<T>(encoded: string): T | null {
+    try {
+        const json = new TextDecoder().decode(base64UrlToBytes(encoded));
+        return JSON.parse(json) as T;
+    } catch {
+        return null;
+    }
+}
+
+/**
+ * Canonical payload for HMAC over the proxy start request.
+ * Field order is fixed so app and proxy produce the same signature.
+ */
+export function canonicalProxyStartPayload(params: ProxyStartParams): string {
+    return `v1\n${params.returnOrigin}\n${params.returnPath}\n${params.exp}\n${params.nonce}`;
+}
+
+export async function signProxyStart(secret: string, params: ProxyStartParams): Promise<string> {
+    return hmacSign(secret, canonicalProxyStartPayload(params));
+}
+
+export async function verifyProxyStartSignature(
+    secret: string,
+    params: ProxyStartParams,
+    signature: string | null | undefined
+): Promise<boolean> {
+    if (!signature) {
+        return false;
+    }
+
+    if (params.exp < Math.floor(Date.now() / 1000)) {
+        return false;
+    }
+
+    const expected = await signProxyStart(secret, params);
+    return timingSafeEqualString(signature, expected);
+}
+
+export async function buildProxyStartUrl(options: {
+    authProxyUrl: string;
+    secret: string;
+    returnOrigin: string;
+    returnPath: string;
+    ttlSeconds?: number;
+}): Promise<string> {
+    const returnPath = safeReturnTo(options.returnPath);
+    const params: ProxyStartParams = {
+        returnOrigin: options.returnOrigin.replace(/\/$/, ""),
+        returnPath,
+        exp: Math.floor(Date.now() / 1000) + (options.ttlSeconds ?? PROXY_START_TTL_SECONDS),
+        nonce: randomToken(16),
+    };
+    const sig = await signProxyStart(options.secret, params);
+    const url = new URL("/start", ensureTrailingSlashBase(options.authProxyUrl));
+    url.searchParams.set("return_origin", params.returnOrigin);
+    url.searchParams.set("return_path", params.returnPath);
+    url.searchParams.set("exp", String(params.exp));
+    url.searchParams.set("nonce", params.nonce);
+    url.searchParams.set("sig", sig);
+    return url.toString();
+}
+
+function ensureTrailingSlashBase(value: string): string {
+    try {
+        const url = new URL(value);
+        return url.toString().endsWith("/") ? url.toString() : `${url.toString()}/`;
+    } catch {
+        return value.endsWith("/") ? value : `${value}/`;
+    }
+}
+
+export async function createHandoffToken(
+    secret: string,
+    audienceOrigin: string,
+    subject: string,
+    ttlSeconds = HANDOFF_TTL_SECONDS
+): Promise<string> {
+    const payload: HandoffPayload = {
+        exp: Math.floor(Date.now() / 1000) + ttlSeconds,
+        aud: audienceOrigin.replace(/\/$/, ""),
+        subject,
+        method: "vercel",
+    };
+    const body = encodeJson(payload);
+    const signature = await hmacSign(secret, body);
+    return `${body}.${signature}`;
+}
+
+export async function verifyHandoffToken(
+    secret: string,
+    token: string | null | undefined,
+    expectedAudienceOrigin: string
+): Promise<HandoffPayload | null> {
+    if (!token) {
+        return null;
+    }
+
+    const [body, signature] = token.split(".");
+
+    if (!body || !signature) {
+        return null;
+    }
+
+    const expected = await hmacSign(secret, body);
+
+    if (!(await timingSafeEqualString(signature, expected))) {
+        return null;
+    }
+
+    const payload = decodeJson<HandoffPayload>(body);
+
+    if (
+        !payload ||
+        typeof payload.exp !== "number" ||
+        typeof payload.aud !== "string" ||
+        typeof payload.subject !== "string" ||
+        payload.method !== "vercel"
+    ) {
+        return null;
+    }
+
+    if (payload.exp < Math.floor(Date.now() / 1000)) {
+        return null;
+    }
+
+    const expectedAud = expectedAudienceOrigin.replace(/\/$/, "");
+
+    if (!(await timingSafeEqualString(payload.aud, expectedAud))) {
+        return null;
+    }
+
+    return payload;
+}
+
+/**
+ * Validate a post-login return origin for the auth proxy.
+ * Only https (and http://localhost / 127.0.0.1) are accepted.
+ */
+export function normalizeReturnOrigin(value: string | null | undefined): string | null {
+    if (typeof value !== "string" || value.length === 0 || value.length > 512) {
+        return null;
+    }
+
+    let url: URL;
+
+    try {
+        url = new URL(value);
+    } catch {
+        return null;
+    }
+
+    if (url.username || url.password) {
+        return null;
+    }
+
+    const host = url.hostname.toLowerCase();
+    const isLocalHttp =
+        url.protocol === "http:" &&
+        (host === "localhost" || host === "127.0.0.1" || host === "[::1]");
+
+    if (url.protocol !== "https:" && !isLocalHttp) {
+        return null;
+    }
+
+    // Origin only — reject unexpected path/query/hash noise by normalizing.
+    return url.origin;
+}
+
+/**
+ * Optional allowlist. Entries may be:
+ * - full origins (`https://app.example.com`)
+ * - hostname suffixes (`.vercel.app`, `example.com`)
+ * - `localhost` (any localhost / 127.0.0.1 http(s) origin)
+ *
+ * Empty allowlist → any origin that passes {@link normalizeReturnOrigin}.
+ */
+export function isReturnOriginAllowed(origin: string, allowlist: string[]): boolean {
+    if (allowlist.length === 0) {
+        return true;
+    }
+
+    let url: URL;
+
+    try {
+        url = new URL(origin);
+    } catch {
+        return false;
+    }
+
+    const host = url.hostname.toLowerCase();
+
+    for (const raw of allowlist) {
+        const entry = raw.trim().toLowerCase();
+
+        if (!entry) {
+            continue;
+        }
+
+        if (entry === "localhost") {
+            if (host === "localhost" || host === "127.0.0.1" || host === "[::1]") {
+                return true;
+            }
+            continue;
+        }
+
+        if (entry.startsWith("http://") || entry.startsWith("https://")) {
+            try {
+                if (new URL(entry).origin.toLowerCase() === origin.toLowerCase()) {
+                    return true;
+                }
+            } catch {
+                // ignore invalid allowlist entries
+            }
+            continue;
+        }
+
+        const suffix = entry.startsWith(".") ? entry : `.${entry}`;
+
+        if (host === entry || host === entry.replace(/^\./, "") || host.endsWith(suffix)) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+export function parseAllowlist(value: string | null | undefined): string[] {
+    if (!value) {
+        return [];
+    }
+
+    return value
+        .split(",")
+        .map(part => part.trim())
+        .filter(Boolean);
+}

--- a/packages/deployment-protection/src/index.ts
+++ b/packages/deployment-protection/src/index.ts
@@ -1,7 +1,20 @@
 export { INTERNAL_PATH_PREFIX, VERCEL_AUTHORIZE_PATH, VERCEL_CALLBACK_PATH } from "./constants";
+export {
+    AUTH_PROXY_CALLBACK_PATH,
+    AUTH_PROXY_START_PATH,
+    handleAuthProxyCallback,
+    handleAuthProxyStart,
+} from "./auth-proxy";
 export { handleDeploymentProtection } from "./handler";
 export { withDeploymentProtection } from "./middleware";
-export { resolveConfig, hasPasswordAuth, hasVercelAuth, isProtectionActive } from "./config";
+export {
+    resolveConfig,
+    hasPasswordAuth,
+    hasVercelAuth,
+    hasVercelDirectAuth,
+    hasVercelProxyAuth,
+    isProtectionActive,
+} from "./config";
 export type {
     AuthMethod,
     DeploymentProtectionConfig,

--- a/packages/deployment-protection/src/types.ts
+++ b/packages/deployment-protection/src/types.ts
@@ -5,7 +5,22 @@ export interface DeploymentProtectionConfig {
     username: string | null;
     password: string | null;
     secret: string | null;
+    /**
+     * Shared secret used to sign proxy start requests and verify handoff tokens.
+     * Falls back to {@link secret} when unset.
+     */
+    handoffSecret: string | null;
     bypassSecret: string | null;
+    /**
+     * Base URL of the central auth-proxy app (e.g. https://dp-auth.example.com).
+     * When set, protected apps no longer need per-host Vercel OAuth callback URLs.
+     */
+    authProxyUrl: string | null;
+    /**
+     * Optional allowlist for auth-proxy return origins (proxy side).
+     * See README for entry formats.
+     */
+    allowedReturnOrigins: string[];
     vercelClientId: string | null;
     vercelClientSecret: string | null;
     sessionTtlSeconds: number;

--- a/packages/deployment-protection/src/vercel-oauth.ts
+++ b/packages/deployment-protection/src/vercel-oauth.ts
@@ -1,6 +1,7 @@
 import {
     OAUTH_NONCE_COOKIE,
     OAUTH_RETURN_COOKIE,
+    OAUTH_RETURN_ORIGIN_COOKIE,
     OAUTH_STATE_COOKIE,
     OAUTH_VERIFIER_COOKIE,
     VERCEL_CALLBACK_PATH,
@@ -24,6 +25,14 @@ export interface VercelUserInfo {
     preferred_username?: string;
 }
 
+export interface VercelOAuthPathOptions {
+    /**
+     * Absolute path used as the OAuth redirect_uri path on the current origin.
+     * Defaults to the protected-app callback path. Auth-proxy uses `/callback`.
+     */
+    callbackPath?: string;
+}
+
 function cookieOptions(secure: boolean) {
     return {
         httpOnly: true,
@@ -34,10 +43,15 @@ function cookieOptions(secure: boolean) {
     };
 }
 
+function resolveCallbackPath(options?: VercelOAuthPathOptions): string {
+    return options?.callbackPath ?? VERCEL_CALLBACK_PATH;
+}
+
 export async function buildVercelAuthorizeRedirect(
     request: Request,
     config: DeploymentProtectionConfig,
-    returnTo: string
+    returnTo: string,
+    options?: VercelOAuthPathOptions
 ): Promise<Response> {
     if (!config.vercelClientId) {
         return new Response("Vercel OAuth is not configured", { status: 500 });
@@ -48,7 +62,7 @@ export async function buildVercelAuthorizeRedirect(
     const codeVerifier = randomToken(48);
     const codeChallenge = await sha256Base64Url(codeVerifier);
     const origin = new URL(request.url).origin;
-    const redirectUri = `${origin}${VERCEL_CALLBACK_PATH}`;
+    const redirectUri = `${origin}${resolveCallbackPath(options)}`;
     const secure = origin.startsWith("https://");
 
     const params = new URLSearchParams({
@@ -82,7 +96,8 @@ export async function exchangeVercelCode(
     request: Request,
     config: DeploymentProtectionConfig,
     code: string,
-    codeVerifier: string
+    codeVerifier: string,
+    options?: VercelOAuthPathOptions
 ): Promise<VercelTokenResponse> {
     if (!config.vercelClientId || !config.vercelClientSecret) {
         throw new Error("Vercel OAuth is not configured");
@@ -95,7 +110,7 @@ export async function exchangeVercelCode(
         client_secret: config.vercelClientSecret,
         code,
         code_verifier: codeVerifier,
-        redirect_uri: `${origin}${VERCEL_CALLBACK_PATH}`,
+        redirect_uri: `${origin}${resolveCallbackPath(options)}`,
     });
 
     const response = await fetch("https://api.vercel.com/login/oauth/token", {
@@ -192,6 +207,7 @@ export function clearOAuthCookies(response: Response, secure: boolean): void {
         OAUTH_NONCE_COOKIE,
         OAUTH_VERIFIER_COOKIE,
         OAUTH_RETURN_COOKIE,
+        OAUTH_RETURN_ORIGIN_COOKIE,
     ]) {
         appendSetCookie(response, name, "", expired);
     }


### PR DESCRIPTION
## Problem
`@becklyn/deployment-protection` builds the Vercel OAuth `redirect_uri` from each app origin, so every production/preview/localhost host must be registered on the Vercel OAuth app.

## Solution
Central auth-proxy pattern:

1. Protected apps set `DEPLOYMENT_PROTECTION_AUTH_PROXY_URL` + shared handoff secret
2. App signs a start request (`return_origin`, `return_path`, exp, nonce) and redirects to `{proxy}/start`
3. Proxy runs Sign in with Vercel against a **single** fixed callback: `{proxy}/callback`
4. Proxy redirects back with a short-lived audience-bound handoff token
5. App verifies handoff, sets its own `__becklyn_dp_session` cookie

### Package (`@becklyn/deployment-protection`)
- Proxy mode via `DEPLOYMENT_PROTECTION_AUTH_PROXY_URL`
- Optional `DEPLOYMENT_PROTECTION_HANDOFF_SECRET` (falls back to `DEPLOYMENT_PROTECTION_SECRET`)
- Optional origin allowlist: `DEPLOYMENT_PROTECTION_ALLOWED_ORIGINS`
- Exports `handleAuthProxyStart` / `handleAuthProxyCallback`
- Legacy direct OAuth still works when auth-proxy URL is unset (proxy wins if both configured)

### App (`@becklyn/deployment-protection-auth-proxy`)
- Private thin Next.js app with `/start` + `/callback`
- Deploy once; register only `https://<host>/callback` on the Vercel OAuth app

## Security
- No raw shared secret in URLs (HMAC signatures + handoff tokens only)
- Handoff tokens are short-lived and bound to `aud` = app origin
- Optional return-origin allowlist on the proxy

## Test plan
- [x] Unit tests for handoff, proxy start/callback, and app proxy mode
- [x] Package + auth-proxy lint/build
- [ ] Deploy auth-proxy and wire one project with `DEPLOYMENT_PROTECTION_AUTH_PROXY_URL`