### PR TITLE
feat(deployment-protection): Storybook deployment protection

### DIFF
--- a/.changeset/storybook-deployment-protection.md
+++ b/.changeset/storybook-deployment-protection.md
@@ -1,0 +1,5 @@
+---
+"@becklyn/deployment-protection": minor
+---
+
+Add Storybook / static deploy support via Vercel Edge Middleware (`@becklyn/deployment-protection/storybook` and `./edge`) using the same env-based gate as Next.js, without requiring the `next` package.

--- a/packages/deployment-protection/DECISIONS.md
+++ b/packages/deployment-protection/DECISIONS.md
@@ -1,0 +1,8 @@
+# Decisions
+
+## Storybook uses Vercel Edge Middleware (not Storybook config)
+
+- Built Storybook is a static site (`storybook-static`); Storybook `main.ts` / Vite hooks cannot gate production traffic.
+- Reuse the existing `handleDeploymentProtection` core via a Next-free edge wrapper that emits `x-middleware-next` for pass-through.
+- Configure with a root `middleware.ts` importing `@becklyn/deployment-protection/storybook` and the same env vars as Next apps.
+- Keep `next` as an optional peer dependency so Storybook-only projects are not forced to install Next.js.

--- a/packages/deployment-protection/README.md
+++ b/packages/deployment-protection/README.md
@@ -1,6 +1,6 @@
 # `@becklyn/deployment-protection`
 
-Simple, shared deployment gate for Next.js apps on Vercel.
+Simple, shared deployment gate for Next.js apps and static Storybook deploys on Vercel.
 
 Use this instead of (or after disabling) Vercel platform Deployment Protection when you need:
 
@@ -9,7 +9,10 @@ Use this instead of (or after disabling) Vercel platform Deployment Protection w
 - always-on **automation bypass** via `x-vercel-protection-bypass` / `VERCEL_AUTOMATION_BYPASS_SECRET`
 - a kill switch (`DEPLOYMENT_PROTECTION_ENABLED`, on by default)
 
-Protection runs in Next.js **middleware** (Next ≤15) or **proxy** (Next 16+).
+Protection runs in:
+
+- Next.js **middleware** (Next ≤15) or **proxy** (Next 16+)
+- **Vercel Edge Middleware** for static Storybook (`@becklyn/deployment-protection/storybook`)
 
 > **Note:** Vercel Connect is unrelated (third-party API tokens). Platform Vercel Authentication cookies are not visible to your app once platform protection is off — team members use the **Sign in with Vercel** button instead.
 
@@ -21,7 +24,45 @@ npm i @becklyn/deployment-protection
 
 ## Quick setup
 
-### 1. Middleware / proxy
+### Storybook (static on Vercel)
+
+Built Storybook is static (`storybook-static`), so protection is **Vercel Edge Middleware** — not a Storybook addon.
+
+1. Install the package in the project that deploys Storybook.
+2. Add `middleware.ts` at the **Vercel project root** (same level Vercel uses for `vercel.json` / output):
+
+```ts
+import { withStorybookDeploymentProtection } from "@becklyn/deployment-protection/storybook";
+
+export default withStorybookDeploymentProtection();
+
+export const config = {
+    matcher: ["/((?!.*\\.(?:svg|png|jpg|jpeg|gif|webp|ico|css|js|map|txt|xml|woff2?|mjs)$).*)"],
+};
+```
+
+3. Set the same environment variables as for Next.js (below).
+4. Optional `vercel.json` for a Storybook-only project:
+
+```json
+{
+    "buildCommand": "npm run build-storybook",
+    "outputDirectory": "storybook-static",
+    "framework": null
+}
+```
+
+`withStorybookDeploymentProtection` does **not** require the `next` package. The matcher must stay a **string literal** in `middleware.ts` (same static-analysis rule as Next.js).
+
+Framework-agnostic alias (same implementation):
+
+```ts
+import { withEdgeDeploymentProtection } from "@becklyn/deployment-protection/edge";
+
+export default withEdgeDeploymentProtection();
+```
+
+### 1. Next.js middleware / proxy
 
 Next.js requires `config.matcher` to be a **string literal in the local middleware/proxy file**.
 It cannot be imported from a package (Next analyzes the matcher statically at build time).
@@ -205,10 +246,13 @@ import {
     handleDeploymentProtection,
     resolveConfig,
     withDeploymentProtection,
+    withEdgeDeploymentProtection,
 } from "@becklyn/deployment-protection";
+import { withStorybookDeploymentProtection } from "@becklyn/deployment-protection/storybook";
 ```
 
-- `withDeploymentProtection(options?)` / `withDeploymentProtection(next, options?)` — middleware/proxy factory
+- `withDeploymentProtection(options?)` / `withDeploymentProtection(next, options?)` — Next.js middleware/proxy factory
+- `withStorybookDeploymentProtection(options?)` / `withEdgeDeploymentProtection(options?)` — Vercel Edge Middleware for Storybook / static deploys (no Next.js)
 - `handleDeploymentProtection(request, options?)` — framework-agnostic core (`null` = continue)
 - `handleAuthProxyStart` / `handleAuthProxyCallback` — central auth-proxy routes
 

--- a/packages/deployment-protection/package.json
+++ b/packages/deployment-protection/package.json
@@ -2,7 +2,7 @@
     "name": "@becklyn/deployment-protection",
     "version": "0.3.0",
     "license": "MIT",
-    "description": "Simple shared username/password + Sign in with Vercel gate for Next.js deployments",
+    "description": "Simple shared username/password + Sign in with Vercel gate for Next.js and Storybook deployments",
     "homepage": "https://github.com/Becklyn-Studios/ts-libs/tree/main/packages/deployment-protection",
     "repository": {
         "type": "git",
@@ -26,6 +26,11 @@
     "peerDependencies": {
         "next": "^14.0.0 || ^15.0.0 || ^16.0.0"
     },
+    "peerDependenciesMeta": {
+        "next": {
+            "optional": true
+        }
+    },
     "files": [
         "dist"
     ],
@@ -38,6 +43,18 @@
             "require": "./dist/cjs/index.js",
             "import": "./dist/es/index.js",
             "default": "./dist/cjs/index.js"
+        },
+        "./storybook": {
+            "types": "./dist/cjs/storybook.d.ts",
+            "require": "./dist/cjs/storybook.js",
+            "import": "./dist/es/storybook.js",
+            "default": "./dist/cjs/storybook.js"
+        },
+        "./edge": {
+            "types": "./dist/cjs/edge.d.ts",
+            "require": "./dist/cjs/edge.js",
+            "import": "./dist/es/edge.js",
+            "default": "./dist/cjs/edge.js"
         },
         "./package.json": "./package.json"
     },

--- a/packages/deployment-protection/src/edge.test.ts
+++ b/packages/deployment-protection/src/edge.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { SESSION_COOKIE_NAME } from "./constants";
+import { middlewarePassThrough, withEdgeDeploymentProtection } from "./edge";
+import { createSessionToken } from "./session";
+
+const baseEnv = {
+    DEPLOYMENT_PROTECTION_USERNAME: "preview",
+    DEPLOYMENT_PROTECTION_PASSWORD: "s3cret",
+    DEPLOYMENT_PROTECTION_SECRET: "super-long-signing-secret",
+};
+
+describe("middlewarePassThrough", () => {
+    it("signals Vercel to continue the request", () => {
+        const response = middlewarePassThrough();
+        expect(response.status).toBe(200);
+        expect(response.headers.get("x-middleware-next")).toBe("1");
+    });
+});
+
+describe("withEdgeDeploymentProtection", () => {
+    it("returns the login page when unauthenticated", async () => {
+        const middleware = withEdgeDeploymentProtection({ env: baseEnv });
+        const response = await middleware(new Request("https://storybook.example.com/"));
+        expect(response.status).toBe(401);
+        expect(await response.text()).toContain("Authentication required");
+        expect(response.headers.get("x-middleware-next")).toBeNull();
+    });
+
+    it("passes through when a valid session cookie is present", async () => {
+        const token = await createSessionToken(
+            baseEnv.DEPLOYMENT_PROTECTION_SECRET,
+            "password",
+            "preview",
+            60
+        );
+        const middleware = withEdgeDeploymentProtection({ env: baseEnv });
+        const response = await middleware(
+            new Request("https://storybook.example.com/", {
+                headers: {
+                    cookie: `${SESSION_COOKIE_NAME}=${encodeURIComponent(token)}`,
+                },
+            })
+        );
+        expect(response.status).toBe(200);
+        expect(response.headers.get("x-middleware-next")).toBe("1");
+    });
+
+    it("is a no-op when protection is disabled", async () => {
+        const middleware = withEdgeDeploymentProtection({
+            env: {
+                ...baseEnv,
+                DEPLOYMENT_PROTECTION_ENABLED: "false",
+            },
+        });
+        const response = await middleware(new Request("https://storybook.example.com/"));
+        expect(response.headers.get("x-middleware-next")).toBe("1");
+    });
+});

--- a/packages/deployment-protection/src/edge.ts
+++ b/packages/deployment-protection/src/edge.ts
@@ -1,0 +1,33 @@
+import { handleDeploymentProtection } from "./handler";
+import type { DeploymentProtectionOptions } from "./types";
+
+/**
+ * Tell Vercel Edge Middleware to continue to the upstream / static asset.
+ * Same signal as `NextResponse.next()` without depending on the Next.js runtime.
+ */
+export function middlewarePassThrough(): Response {
+    return new Response(null, {
+        status: 200,
+        headers: {
+            "x-middleware-next": "1",
+        },
+    });
+}
+
+/**
+ * Framework-agnostic Vercel Edge Middleware factory (no Next.js runtime).
+ *
+ * Intended for static deployments such as Storybook `storybook-static` on Vercel.
+ * Reuses the same env vars and auth behaviour as {@link withDeploymentProtection}.
+ */
+export function withEdgeDeploymentProtection(options: DeploymentProtectionOptions = {}) {
+    return async function deploymentProtectionEdgeMiddleware(request: Request): Promise<Response> {
+        const protectionResponse = await handleDeploymentProtection(request, options);
+
+        if (protectionResponse) {
+            return protectionResponse;
+        }
+
+        return middlewarePassThrough();
+    };
+}

--- a/packages/deployment-protection/src/index.ts
+++ b/packages/deployment-protection/src/index.ts
@@ -7,6 +7,7 @@ export {
 } from "./auth-proxy";
 export { handleDeploymentProtection } from "./handler";
 export { withDeploymentProtection } from "./middleware";
+export { middlewarePassThrough, withEdgeDeploymentProtection } from "./edge";
 export {
     resolveConfig,
     hasPasswordAuth,

--- a/packages/deployment-protection/src/storybook.ts
+++ b/packages/deployment-protection/src/storybook.ts
@@ -1,0 +1,35 @@
+/**
+ * Storybook deployment protection for Vercel.
+ *
+ * Built Storybooks are static sites, so protection runs as **Vercel Edge Middleware**
+ * (not Storybook config). Drop a `middleware.ts` next to the Vercel project root that
+ * serves `storybook-static` and set the same env vars as the Next.js integration.
+ *
+ * @example middleware.ts
+ * ```ts
+ * import { withStorybookDeploymentProtection } from "@becklyn/deployment-protection/storybook";
+ *
+ * export default withStorybookDeploymentProtection();
+ *
+ * // Matcher must be a string literal in this file (Vercel/Next static analysis).
+ * export const config = {
+ *   matcher: [
+ *     "/((?!.*\\.(?:svg|png|jpg|jpeg|gif|webp|ico|css|js|map|txt|xml|woff2?|mjs)$).*)",
+ *   ],
+ * };
+ * ```
+ *
+ * Optional `vercel.json` for a Storybook-only project:
+ * ```json
+ * {
+ *   "buildCommand": "npm run build-storybook",
+ *   "outputDirectory": "storybook-static",
+ *   "framework": null
+ * }
+ * ```
+ */
+export {
+    middlewarePassThrough,
+    withEdgeDeploymentProtection as withStorybookDeploymentProtection,
+} from "./edge";
+export type { DeploymentProtectionOptions } from "./types";


### PR DESCRIPTION
## Summary

Adds deployment protection for static Storybook deploys on Vercel to `@becklyn/deployment-protection`, reusing the existing password / Vercel SSO / bypass gate.

Built Storybook is static, so this is **Vercel Edge Middleware** (not a Storybook addon), exposed as a simple drop-in.

## Usage

```ts
// middleware.ts (Vercel project root for the Storybook deployment)
import { withStorybookDeploymentProtection } from "@becklyn/deployment-protection/storybook";

export default withStorybookDeploymentProtection();

export const config = {
  matcher: [
    "/((?!.*\\.(?:svg|png|jpg|jpeg|gif|webp|ico|css|js|map|txt|xml|woff2?|mjs)$).*)",
  ],
};
```

Same env vars as the Next.js integration (`DEPLOYMENT_PROTECTION_*`, optional auth-proxy, automation bypass).

## Changes

- `withEdgeDeploymentProtection` / `middlewarePassThrough` (Next-free; pass-through via `x-middleware-next`)
- `@becklyn/deployment-protection/storybook` convenience entry (`withStorybookDeploymentProtection`)
- `@becklyn/deployment-protection/edge` entry
- `next` is now an **optional** peer dependency
- README + package `DECISIONS.md`
- Unit tests for the edge middleware
- Changeset (minor)

## Test plan

- [x] `npm test` in `@becklyn/deployment-protection`
- [x] `npm run lint` + `npm run build`
- [ ] Deploy a Storybook preview with the new middleware + shared credentials
- [ ] Confirm login, session cookie, and automation bypass still work