### PR TITLE
fix(deployment-protection): self-contained Storybook/edge middleware bundles

### DIFF
--- a/.changeset/fix-storybook-edge-bundles.md
+++ b/.changeset/fix-storybook-edge-bundles.md
@@ -1,0 +1,5 @@
+---
+"@becklyn/deployment-protection": patch
+---
+
+Fix Storybook/static Vercel middleware by shipping self-contained `./edge` and `./storybook` ESM bundles. Resolves edge "unsupported modules" and nodejs named-export failures from multi-file tsc output.

--- a/package-lock.json
+++ b/package-lock.json
@@ -15436,18 +15436,24 @@
         },
         "packages/deployment-protection": {
             "name": "@becklyn/deployment-protection",
-            "version": "0.2.0",
+            "version": "0.4.0",
             "license": "MIT",
             "devDependencies": {
                 "@becklyn/eslint": "*",
                 "@becklyn/tsconfig": "*",
                 "@types/node": "^25.9.5",
+                "esbuild": "^0.25.12",
                 "next": "^16.3.0",
                 "typescript": "^5.9.3",
                 "vitest": "^3.2.4"
             },
             "peerDependencies": {
                 "next": "^14.0.0 || ^15.0.0 || ^16.0.0"
+            },
+            "peerDependenciesMeta": {
+                "next": {
+                    "optional": true
+                }
             }
         },
         "packages/deployment-protection-auth-proxy": {
@@ -15466,6 +15472,490 @@
                 "@types/react": "^19.2.18",
                 "@types/react-dom": "^19.2.4",
                 "typescript": "^5.9.3"
+            }
+        },
+        "packages/deployment-protection/node_modules/@esbuild/aix-ppc64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+            "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "aix"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "packages/deployment-protection/node_modules/@esbuild/android-arm": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+            "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "packages/deployment-protection/node_modules/@esbuild/android-arm64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+            "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "packages/deployment-protection/node_modules/@esbuild/android-x64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+            "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "packages/deployment-protection/node_modules/@esbuild/darwin-arm64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+            "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "packages/deployment-protection/node_modules/@esbuild/darwin-x64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+            "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "packages/deployment-protection/node_modules/@esbuild/freebsd-arm64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+            "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "packages/deployment-protection/node_modules/@esbuild/freebsd-x64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+            "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "packages/deployment-protection/node_modules/@esbuild/linux-arm": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+            "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "packages/deployment-protection/node_modules/@esbuild/linux-arm64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+            "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "packages/deployment-protection/node_modules/@esbuild/linux-ia32": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+            "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "packages/deployment-protection/node_modules/@esbuild/linux-loong64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+            "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+            "cpu": [
+                "loong64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "packages/deployment-protection/node_modules/@esbuild/linux-mips64el": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+            "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+            "cpu": [
+                "mips64el"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "packages/deployment-protection/node_modules/@esbuild/linux-ppc64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+            "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "packages/deployment-protection/node_modules/@esbuild/linux-riscv64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+            "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "packages/deployment-protection/node_modules/@esbuild/linux-s390x": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+            "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+            "cpu": [
+                "s390x"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "packages/deployment-protection/node_modules/@esbuild/linux-x64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+            "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "packages/deployment-protection/node_modules/@esbuild/netbsd-arm64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+            "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "netbsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "packages/deployment-protection/node_modules/@esbuild/netbsd-x64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+            "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "netbsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "packages/deployment-protection/node_modules/@esbuild/openbsd-arm64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+            "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openbsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "packages/deployment-protection/node_modules/@esbuild/openbsd-x64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+            "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openbsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "packages/deployment-protection/node_modules/@esbuild/openharmony-arm64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+            "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openharmony"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "packages/deployment-protection/node_modules/@esbuild/sunos-x64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+            "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "sunos"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "packages/deployment-protection/node_modules/@esbuild/win32-arm64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+            "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "packages/deployment-protection/node_modules/@esbuild/win32-ia32": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+            "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "packages/deployment-protection/node_modules/@esbuild/win32-x64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+            "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "packages/deployment-protection/node_modules/esbuild": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+            "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+            "dev": true,
+            "hasInstallScript": true,
+            "license": "MIT",
+            "bin": {
+                "esbuild": "bin/esbuild"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "optionalDependencies": {
+                "@esbuild/aix-ppc64": "0.25.12",
+                "@esbuild/android-arm": "0.25.12",
+                "@esbuild/android-arm64": "0.25.12",
+                "@esbuild/android-x64": "0.25.12",
+                "@esbuild/darwin-arm64": "0.25.12",
+                "@esbuild/darwin-x64": "0.25.12",
+                "@esbuild/freebsd-arm64": "0.25.12",
+                "@esbuild/freebsd-x64": "0.25.12",
+                "@esbuild/linux-arm": "0.25.12",
+                "@esbuild/linux-arm64": "0.25.12",
+                "@esbuild/linux-ia32": "0.25.12",
+                "@esbuild/linux-loong64": "0.25.12",
+                "@esbuild/linux-mips64el": "0.25.12",
+                "@esbuild/linux-ppc64": "0.25.12",
+                "@esbuild/linux-riscv64": "0.25.12",
+                "@esbuild/linux-s390x": "0.25.12",
+                "@esbuild/linux-x64": "0.25.12",
+                "@esbuild/netbsd-arm64": "0.25.12",
+                "@esbuild/netbsd-x64": "0.25.12",
+                "@esbuild/openbsd-arm64": "0.25.12",
+                "@esbuild/openbsd-x64": "0.25.12",
+                "@esbuild/openharmony-arm64": "0.25.12",
+                "@esbuild/sunos-x64": "0.25.12",
+                "@esbuild/win32-arm64": "0.25.12",
+                "@esbuild/win32-ia32": "0.25.12",
+                "@esbuild/win32-x64": "0.25.12"
             }
         },
         "packages/eslint": {

--- a/packages/deployment-protection/DECISIONS.md
+++ b/packages/deployment-protection/DECISIONS.md
@@ -6,3 +6,10 @@
 - Reuse the existing `handleDeploymentProtection` core via a Next-free edge wrapper that emits `x-middleware-next` for pass-through.
 - Configure with a root `middleware.ts` importing `@becklyn/deployment-protection/storybook` and the same env vars as Next apps.
 - Keep `next` as an optional peer dependency so Storybook-only projects are not forced to install Next.js.
+
+## Ship self-contained ESM bundles for `./edge` and `./storybook`
+
+- Vercel Routing Middleware (edge + nodejs) file-traces imports with NFT and loads them in a restricted runtime — it does not reliably bundle multi-file package graphs.
+- tsc `dist/es/*` used extensionless relative imports and no `type: module`, so Node ESM/`runtime: "nodejs"` failed, and edge builds reported `@becklyn/deployment-protection/edge` as an unsupported module.
+- Build zero-import `dist/edge.mjs` + `dist/storybook.mjs` with esbuild and point export conditions (`edge-light`, `worker`, `browser`, `import`, `default`) at those files.
+- Do **not** use Vercel framework preset `storybook` for protected deploys (`disableRootMiddleware: true`); use `framework: null`.

--- a/packages/deployment-protection/README.md
+++ b/packages/deployment-protection/README.md
@@ -26,9 +26,9 @@ npm i @becklyn/deployment-protection
 
 ### Storybook (static on Vercel)
 
-Built Storybook is static (`storybook-static`), so protection is **Vercel Edge Middleware** — not a Storybook addon.
+Built Storybook is static (`storybook-static`), so protection is **Vercel Routing Middleware** — not a Storybook addon.
 
-1. Install the package in the project that deploys Storybook.
+1. Install the package in the project that deploys Storybook (published build, or workspace package after `npm run build`).
 2. Add `middleware.ts` at the **Vercel project root** (same level Vercel uses for `vercel.json` / output):
 
 ```ts
@@ -42,7 +42,7 @@ export const config = {
 ```
 
 3. Set the same environment variables as for Next.js (below).
-4. Optional `vercel.json` for a Storybook-only project:
+4. `vercel.json` for a Storybook-only project — **`framework` must be `null`** (Other). Do **not** use the Vercel “Storybook” framework preset; it sets `disableRootMiddleware` and skips middleware entirely:
 
 ```json
 {
@@ -53,6 +53,8 @@ export const config = {
 ```
 
 `withStorybookDeploymentProtection` does **not** require the `next` package. The matcher must stay a **string literal** in `middleware.ts` (same static-analysis rule as Next.js).
+
+Prefer the default **edge** runtime. `runtime: "nodejs"` is supported as well — both resolve to a self-contained ESM bundle (`dist/storybook.mjs` / `dist/edge.mjs`) so Vercel does not need to trace the multi-file tsc graph.
 
 Framework-agnostic alias (same implementation):
 

--- a/packages/deployment-protection/eslint.config.mjs
+++ b/packages/deployment-protection/eslint.config.mjs
@@ -1,4 +1,4 @@
-import {config} from "@becklyn/eslint/base";
+import { config } from "@becklyn/eslint/base";
 
 /** @type {import("eslint").Linter.Config} */
 export default [...config];

--- a/packages/deployment-protection/package.json
+++ b/packages/deployment-protection/package.json
@@ -9,16 +9,17 @@
         "url": "git+https://github.com/Becklyn-Studios/ts-libs.git"
     },
     "scripts": {
-        "lint": "eslint . --max-warnings 0 && prettier --check \"./**/*.{ts,tsx,md,json}\"",
-        "fix": "eslint . --fix && prettier --write \"./**/*.{ts,tsx,md,json}\"",
-        "test": "vitest run",
-        "build": "rm -rf dist && tsc -p tsconfig-es.json && tsc -p tsconfig-cjs.json",
-        "prepublishOnly": "npm run lint && npm run test && npm run build"
+        "lint": "eslint . --max-warnings 0 && prettier --check \"./**/*.{ts,tsx,md,json,mjs}\"",
+        "fix": "eslint . --fix && prettier --write \"./**/*.{ts,tsx,md,json,mjs}\"",
+        "test": "npm run build && vitest run",
+        "build": "rm -rf dist && tsc -p tsconfig-es.json && tsc -p tsconfig-cjs.json && node ./scripts/build-edge-bundles.mjs",
+        "prepublishOnly": "npm run lint && npm run test"
     },
     "devDependencies": {
         "@becklyn/eslint": "*",
         "@becklyn/tsconfig": "*",
         "@types/node": "^25.9.5",
+        "esbuild": "^0.25.12",
         "next": "^16.3.0",
         "typescript": "^5.9.3",
         "vitest": "^3.2.4"
@@ -46,15 +47,21 @@
         },
         "./storybook": {
             "types": "./dist/cjs/storybook.d.ts",
+            "edge-light": "./dist/storybook.mjs",
+            "worker": "./dist/storybook.mjs",
+            "browser": "./dist/storybook.mjs",
+            "import": "./dist/storybook.mjs",
             "require": "./dist/cjs/storybook.js",
-            "import": "./dist/es/storybook.js",
-            "default": "./dist/cjs/storybook.js"
+            "default": "./dist/storybook.mjs"
         },
         "./edge": {
             "types": "./dist/cjs/edge.d.ts",
+            "edge-light": "./dist/edge.mjs",
+            "worker": "./dist/edge.mjs",
+            "browser": "./dist/edge.mjs",
+            "import": "./dist/edge.mjs",
             "require": "./dist/cjs/edge.js",
-            "import": "./dist/es/edge.js",
-            "default": "./dist/cjs/edge.js"
+            "default": "./dist/edge.mjs"
         },
         "./package.json": "./package.json"
     },

--- a/packages/deployment-protection/scripts/build-edge-bundles.mjs
+++ b/packages/deployment-protection/scripts/build-edge-bundles.mjs
@@ -1,0 +1,60 @@
+/**
+ * Bundle Storybook / static-deploy entry points into self-contained ESM files.
+ *
+ * Vercel Routing Middleware (edge + nodejs) file-traces imports via NFT and
+ * loads them in a restricted runtime. Multi-file tsc output with extensionless
+ * relative imports does not resolve there, and bare package subpaths often show
+ * up as "unsupported modules". A single zero-import .mjs file avoids both.
+ */
+import * as esbuild from "esbuild";
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const outDir = path.join(root, "dist");
+
+/** @type {esbuild.BuildOptions} */
+const shared = {
+    bundle: true,
+    format: "esm",
+    platform: "neutral",
+    target: "es2022",
+    legalComments: "none",
+    // Keep process.env.* as runtime lookups (Vercel injects env at the edge).
+    packages: "bundle",
+    logLevel: "info",
+};
+
+const entries = [
+    {
+        entryPoints: [path.join(root, "src/edge.ts")],
+        outfile: path.join(outDir, "edge.mjs"),
+    },
+    {
+        entryPoints: [path.join(root, "src/storybook.ts")],
+        outfile: path.join(outDir, "storybook.mjs"),
+    },
+];
+
+await mkdir(outDir, { recursive: true });
+
+for (const entry of entries) {
+    await esbuild.build({
+        ...shared,
+        ...entry,
+    });
+}
+
+// Marker so consumers / tests can assert the bundle build ran.
+await writeFile(
+    path.join(outDir, "edge-bundles.json"),
+    `${JSON.stringify(
+        {
+            format: "esm",
+            entries: entries.map(entry => path.relative(root, entry.outfile)),
+        },
+        null,
+        4
+    )}\n`
+);

--- a/packages/deployment-protection/src/edge.bundle.test.ts
+++ b/packages/deployment-protection/src/edge.bundle.test.ts
@@ -1,0 +1,42 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const packageRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+async function importBuiltBundle(relativePath: string): Promise<Record<string, unknown>> {
+    const absolutePath = path.join(packageRoot, relativePath);
+    return import(pathToFileURL(absolutePath).href);
+}
+
+describe("edge/storybook publish bundles", () => {
+    it("ships self-contained ESM bundles with no relative imports", () => {
+        for (const relativePath of ["dist/edge.mjs", "dist/storybook.mjs"] as const) {
+            const source = readFileSync(path.join(packageRoot, relativePath), "utf8");
+            expect(source.length).toBeGreaterThan(500);
+            // Bundles must not reach back into multi-file tsc output.
+            expect(source).not.toMatch(/from\s+["']\.\//);
+            expect(source).not.toMatch(/require\(["']\.\//);
+            // And must not pull Next.js into the Storybook/static path.
+            expect(source).not.toMatch(/next\/server/);
+        }
+    });
+
+    it("exports the public edge API from the edge bundle", async () => {
+        const mod = await importBuiltBundle("dist/edge.mjs");
+        expect(typeof mod.withEdgeDeploymentProtection).toBe("function");
+        expect(typeof mod.middlewarePassThrough).toBe("function");
+
+        const passThrough = (mod.middlewarePassThrough as () => Response)();
+        expect(passThrough.headers.get("x-middleware-next")).toBe("1");
+    });
+
+    it("exports the Storybook alias from the storybook bundle", async () => {
+        const mod = await importBuiltBundle("dist/storybook.mjs");
+        expect(typeof mod.withStorybookDeploymentProtection).toBe("function");
+        expect(typeof mod.middlewarePassThrough).toBe("function");
+        // Rename-only surface: edge factory name is not re-exported here.
+        expect(mod.withEdgeDeploymentProtection).toBeUndefined();
+    });
+});

--- a/packages/deployment-protection/src/storybook.ts
+++ b/packages/deployment-protection/src/storybook.ts
@@ -1,9 +1,13 @@
 /**
  * Storybook deployment protection for Vercel.
  *
- * Built Storybooks are static sites, so protection runs as **Vercel Edge Middleware**
+ * Built Storybooks are static sites, so protection runs as **Vercel Routing Middleware**
  * (not Storybook config). Drop a `middleware.ts` next to the Vercel project root that
  * serves `storybook-static` and set the same env vars as the Next.js integration.
+ *
+ * The published `./storybook` and `./edge` entry points resolve to self-contained ESM
+ * bundles so Vercel edge/nodejs middleware can load them without tracing multi-file
+ * package internals.
  *
  * @example middleware.ts
  * ```ts
@@ -19,7 +23,7 @@
  * };
  * ```
  *
- * Optional `vercel.json` for a Storybook-only project:
+ * Optional `vercel.json` for a Storybook-only project (`framework` must be `null`):
  * ```json
  * {
  *   "buildCommand": "npm run build-storybook",


### PR DESCRIPTION
## Problem

Storybook/static deploys using `@becklyn/deployment-protection/edge` (or `/storybook`) failed on Vercel Routing Middleware:

1. **Edge runtime** – `The Edge Function "middleware" is referencing unsupported modules: @becklyn/deployment-protection/edge`
2. **Nodejs runtime** – `does not provide an export named 'withEdgeDeploymentProtection'`

Root cause: `./edge` and `./storybook` pointed at multi-file `tsc` output (`dist/es/*`) with extensionless relative imports and no Node-native ESM packaging. Vercel middleware is file-traced (NFT) and loaded in a restricted runtime, so that graph does not resolve cleanly.

## Fix

- Bundle `src/edge.ts` and `src/storybook.ts` into zero-import ESM files:
  - `dist/edge.mjs`
  - `dist/storybook.mjs`
- Point export conditions (`edge-light`, `worker`, `browser`, `import`, `default`) at those bundles (Vercel edge prefers `edge-light` / `browser`).
- Keep CJS builds for `require`.
- Add bundle regression tests, README/DECISIONS notes, and a patch changeset.

## Consumer setup (unchanged intent)

```ts
// middleware.ts
import { withEdgeDeploymentProtection } from "@becklyn/deployment-protection/edge";

export default withEdgeDeploymentProtection();

export const config = {
  matcher: [
    "/((?!.*\\.(?:svg|png|jpg|jpeg|gif|webp|ico|css|js|map|txt|xml|woff2?|mjs)$).*)",
  ],
};
```

```json
{
  "buildCommand": "npm run build-storybook",
  "outputDirectory": "storybook-static",
  "framework": null
}
```

Notes:
- Use **`framework: null`**, not the Vercel Storybook preset (`disableRootMiddleware: true`).
- Default edge runtime is fine; `runtime: "nodejs"` should work with the new bundles too.
- Monorepo/workspace consumers need a built package (`dist/`) before deploy.

## Test plan

- [x] `npm test` in `packages/deployment-protection` (build + unit + bundle tests)
- [x] `npm run lint`
- [ ] After publish/workspace bump: redeploy Storybook project and hit a protected URL (login gate + static assets)