### PR TITLE
fix(deployment-protection): set session cookie on bypass query param

### DIFF
--- a/.changeset/dp-bypass-query-session-cookie.md
+++ b/.changeset/dp-bypass-query-session-cookie.md
@@ -1,0 +1,5 @@
+---
+"@becklyn/deployment-protection": patch
+---
+
+Set `__becklyn_dp_session` when `x-vercel-protection-bypass` is present as a query param, including Next.js middleware redirects that previously dropped the cookie.

--- a/.changeset/dp-bypass-query-session-cookie.md
+++ b/.changeset/dp-bypass-query-session-cookie.md
@@ -2,4 +2,4 @@
 "@becklyn/deployment-protection": patch
 ---
 
-Set `__becklyn_dp_session` when `x-vercel-protection-bypass` is present as a query param, including Next.js middleware redirects that previously dropped the cookie.
+Set `__becklyn_dp_session` when `x-vercel-protection-bypass` is present as a query param, including Next.js middleware redirects that previously dropped the cookie. Fix JSDoc matcher examples so copied regexes use `\\.` and still exclude static assets.

--- a/packages/deployment-protection/README.md
+++ b/packages/deployment-protection/README.md
@@ -215,8 +215,18 @@ x-vercel-protection-bypass: <VERCEL_AUTOMATION_BYPASS_SECRET>
 Or query:
 
 ```text
+https://app.example/?x-vercel-protection-bypass=<secret>
+```
+
+A valid bypass query param redirects to the same path without the secret and sets the signed `__becklyn_dp_session` cookie, so later requests stay authenticated. You do not need `x-vercel-set-bypass-cookie` for that.
+
+Optional Vercel-compatible helper — also persist the raw bypass secret as `__becklyn_dp_bypass`:
+
+```text
 https://app.example/?x-vercel-protection-bypass=<secret>&x-vercel-set-bypass-cookie=true
 ```
+
+The header form stays one-shot (no cookies) so CI/Playwright can send it on each request.
 
 When platform Deployment Protection is disabled, **this package** enforces the bypass secret so CI/Playwright keep working the same way.
 
@@ -225,9 +235,10 @@ When platform Deployment Protection is disabled, **this package** enforces the b
 1. Disabled / misconfigured → pass through
 2. Internal Vercel OAuth routes → handled by the package (proxy start or direct OAuth / handoff)
 3. Login form `POST` → validate username/password, set signed HttpOnly session cookie
-4. Valid bypass header/query/cookie → allow (optionally set cookies)
-5. Valid session cookie → allow
-6. Else → HTML login page (password and/or Sign in with Vercel)
+4. Valid bypass header → allow this request
+5. Valid bypass query param → set `__becklyn_dp_session`, redirect to the cleaned URL
+6. Valid session or bypass cookie → allow
+7. Else → HTML login page (password and/or Sign in with Vercel)
 
 Session cookie: `__becklyn_dp_session` (HMAC-SHA256, 14 days by default).
 

--- a/packages/deployment-protection/src/edge.test.ts
+++ b/packages/deployment-protection/src/edge.test.ts
@@ -45,6 +45,21 @@ describe("withEdgeDeploymentProtection", () => {
         expect(response.headers.get("x-middleware-next")).toBe("1");
     });
 
+    it("sets a session cookie when the automation secret is in the query", async () => {
+        const middleware = withEdgeDeploymentProtection({
+            env: {
+                ...baseEnv,
+                VERCEL_AUTOMATION_BYPASS_SECRET: "bypass-secret",
+            },
+        });
+        const response = await middleware(
+            new Request("https://storybook.example.com/?x-vercel-protection-bypass=bypass-secret")
+        );
+        expect(response.status).toBe(302);
+        expect(response.headers.get("Location")).toBe("https://storybook.example.com/");
+        expect(response.headers.get("Set-Cookie")).toContain(SESSION_COOKIE_NAME);
+    });
+
     it("is a no-op when protection is disabled", async () => {
         const middleware = withEdgeDeploymentProtection({
             env: {

--- a/packages/deployment-protection/src/handler.test.ts
+++ b/packages/deployment-protection/src/handler.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { hasPasswordAuth, hasVercelAuth, isProtectionActive, resolveConfig } from "./config";
-import { BYPASS_HEADER, SESSION_COOKIE_NAME } from "./constants";
+import { BYPASS_COOKIE_NAME, BYPASS_HEADER, SESSION_COOKIE_NAME } from "./constants";
 import { timingSafeEqualString } from "./crypto";
 import { handleDeploymentProtection } from "./handler";
 import { createSessionToken, verifySessionToken } from "./session";
@@ -10,6 +10,27 @@ const baseEnv = {
     DEPLOYMENT_PROTECTION_PASSWORD: "s3cret",
     DEPLOYMENT_PROTECTION_SECRET: "super-long-signing-secret",
 };
+
+function setCookieHeader(response: Response): string {
+    const cookies = response.headers.getSetCookie?.() ?? [response.headers.get("Set-Cookie") ?? ""];
+    return cookies.join("\n");
+}
+
+function cookieHeaderFromResponse(response: Response, name: string): string | null {
+    const cookies = response.headers.getSetCookie?.() ?? [response.headers.get("Set-Cookie") ?? ""];
+
+    for (const cookie of cookies) {
+        const [pair] = cookie.split(";");
+
+        if (!pair?.startsWith(`${name}=`)) {
+            continue;
+        }
+
+        return `${name}=${pair.slice(name.length + 1)}`;
+    }
+
+    return null;
+}
 
 describe("resolveConfig", () => {
     it("is enabled by default", () => {
@@ -117,7 +138,7 @@ describe("handleDeploymentProtection", () => {
             __becklyn_dp: "1",
             username: "preview",
             password: "s3cret",
-            return_to: "/\\evil.com",
+            return_to: "/\\\\evil.com",
         });
 
         const response = await handleDeploymentProtection(
@@ -191,6 +212,57 @@ describe("handleDeploymentProtection", () => {
         expect(response).toBeNull();
     });
 
+    it("sets a session cookie when the automation secret is in the query", async () => {
+        const env = {
+            ...baseEnv,
+            VERCEL_AUTOMATION_BYPASS_SECRET: "bypass-secret",
+        };
+        const response = await handleDeploymentProtection(
+            new Request("https://example.com/page?x-vercel-protection-bypass=bypass-secret&keep=1"),
+            { env }
+        );
+
+        expect(response).not.toBeNull();
+        expect(response!.status).toBe(302);
+        expect(response!.headers.get("Location")).toBe("https://example.com/page?keep=1");
+        expect(setCookieHeader(response!)).toContain(SESSION_COOKIE_NAME);
+        expect(setCookieHeader(response!)).not.toContain(BYPASS_COOKIE_NAME);
+
+        const sessionCookie = cookieHeaderFromResponse(response!, SESSION_COOKIE_NAME);
+        expect(sessionCookie).toBeTruthy();
+
+        const followUp = await handleDeploymentProtection(
+            new Request("https://example.com/page?keep=1", {
+                headers: { cookie: sessionCookie! },
+            }),
+            { env }
+        );
+        expect(followUp).toBeNull();
+    });
+
+    it("sets a session cookie from the bypass query even without other auth config", async () => {
+        const env = {
+            VERCEL_AUTOMATION_BYPASS_SECRET: "bypass-secret",
+        };
+        const response = await handleDeploymentProtection(
+            new Request("https://example.com/?x-vercel-protection-bypass=bypass-secret"),
+            { env }
+        );
+
+        expect(response).not.toBeNull();
+        expect(response!.status).toBe(302);
+        expect(setCookieHeader(response!)).toContain(SESSION_COOKIE_NAME);
+
+        const sessionCookie = cookieHeaderFromResponse(response!, SESSION_COOKIE_NAME);
+        const followUp = await handleDeploymentProtection(
+            new Request("https://example.com/", {
+                headers: { cookie: sessionCookie! },
+            }),
+            { env }
+        );
+        expect(followUp).toBeNull();
+    });
+
     it("bypasses with the automation secret query param and sets session", async () => {
         const response = await handleDeploymentProtection(
             new Request(
@@ -206,10 +278,8 @@ describe("handleDeploymentProtection", () => {
         expect(response).not.toBeNull();
         expect(response!.status).toBe(302);
         expect(response!.headers.get("Location")).toBe("https://example.com/page");
-        const cookies = response!.headers.getSetCookie?.() ?? [
-            response!.headers.get("Set-Cookie") ?? "",
-        ];
-        expect(cookies.join("\n")).toContain(SESSION_COOKIE_NAME);
+        expect(setCookieHeader(response!)).toContain(SESSION_COOKIE_NAME);
+        expect(setCookieHeader(response!)).toContain(BYPASS_COOKIE_NAME);
     });
 
     it("shows Sign in with Vercel when configured", async () => {

--- a/packages/deployment-protection/src/handler.ts
+++ b/packages/deployment-protection/src/handler.ts
@@ -14,6 +14,7 @@ import {
     OAUTH_RETURN_COOKIE,
     OAUTH_VERIFIER_COOKIE,
     SESSION_COOKIE_NAME,
+    SET_BYPASS_COOKIE_HEADER,
     VERCEL_AUTHORIZE_PATH,
     VERCEL_CALLBACK_PATH,
 } from "./constants";
@@ -65,6 +66,15 @@ function redirect(request: Request, location: string, status = 302): Response {
     });
 }
 
+/**
+ * Prefer the dedicated session secret; fall back to the automation bypass secret
+ * so a query-param bypass can still persist `__becklyn_dp_session` when no
+ * username/password or explicit HMAC secret is configured.
+ */
+function signingSecret(config: DeploymentProtectionConfig): string | null {
+    return config.secret ?? config.bypassSecret;
+}
+
 async function attachSession(
     response: Response,
     config: DeploymentProtectionConfig,
@@ -72,16 +82,13 @@ async function attachSession(
     subject: string,
     secure: boolean
 ): Promise<Response> {
-    if (!config.secret) {
+    const secret = signingSecret(config);
+
+    if (!secret) {
         return response;
     }
 
-    const token = await createSessionToken(
-        config.secret,
-        method,
-        subject,
-        config.sessionTtlSeconds
-    );
+    const token = await createSessionToken(secret, method, subject, config.sessionTtlSeconds);
     const opts = sessionCookieOptions(config.sessionTtlSeconds, secure);
     appendSetCookie(response, SESSION_COOKIE_NAME, token, opts);
     return response;
@@ -106,11 +113,13 @@ async function handleBypass(
     const setCookieMode = shouldSetBypassCookie(request);
     const url = new URL(request.url);
     const hadQueryBypass = url.searchParams.has(BYPASS_HEADER);
-    const hadSetCookieQuery = url.searchParams.has("x-vercel-set-bypass-cookie");
+    const hadSetCookieQuery = url.searchParams.has(SET_BYPASS_COOKIE_HEADER);
 
+    // Query-param bypass (and the Vercel set-cookie helper) persist auth, then
+    // strip secrets from the URL. Header-only automation stays one-shot.
     if (hadQueryBypass || hadSetCookieQuery || setCookieMode) {
         url.searchParams.delete(BYPASS_HEADER);
-        url.searchParams.delete("x-vercel-set-bypass-cookie");
+        url.searchParams.delete(SET_BYPASS_COOKIE_HEADER);
         const response = redirect(request, url.pathname + url.search + url.hash);
         const secure = isSecureRequest(request);
 
@@ -124,6 +133,7 @@ async function handleBypass(
             });
         }
 
+        // Always persist a signed session when the bypass secret arrived via query.
         await attachSession(response, config, "bypass", "automation", secure);
         return { kind: "respond", response };
     }
@@ -343,11 +353,10 @@ export async function handleDeploymentProtection(
         return null;
     }
 
-    if (config.secret) {
-        const session = await verifySessionToken(
-            config.secret,
-            readCookie(request, SESSION_COOKIE_NAME)
-        );
+    const secret = signingSecret(config);
+
+    if (secret) {
+        const session = await verifySessionToken(secret, readCookie(request, SESSION_COOKIE_NAME));
 
         if (session) {
             return null;

--- a/packages/deployment-protection/src/middleware.test.ts
+++ b/packages/deployment-protection/src/middleware.test.ts
@@ -1,4 +1,7 @@
 import { NextRequest } from "next/server";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 import { SESSION_COOKIE_NAME } from "./constants";
 import { withDeploymentProtection } from "./middleware";
@@ -36,5 +39,26 @@ describe("withDeploymentProtection", () => {
 
         expect(response.status).toBe(302);
         expect(response.cookies.get(SESSION_COOKIE_NAME)?.value).toBeTruthy();
+    });
+});
+
+function packageSource(relativePath: string): string {
+    return readFileSync(
+        path.join(path.dirname(fileURLToPath(import.meta.url)), relativePath),
+        "utf8"
+    );
+}
+
+describe("JSDoc matcher examples", () => {
+    it("use two backslashes so copied regex excludes static assets", () => {
+        for (const file of ["middleware.ts", "storybook.ts"] as const) {
+            const source = packageSource(file);
+            const matches = [...source.matchAll(/\.\*(\\+)\./g)];
+            expect(matches.length).toBeGreaterThan(0);
+
+            for (const match of matches) {
+                expect(match[1], file).toHaveLength(2);
+            }
+        }
     });
 });

--- a/packages/deployment-protection/src/middleware.test.ts
+++ b/packages/deployment-protection/src/middleware.test.ts
@@ -1,0 +1,40 @@
+import { NextRequest } from "next/server";
+import { describe, expect, it } from "vitest";
+import { SESSION_COOKIE_NAME } from "./constants";
+import { withDeploymentProtection } from "./middleware";
+
+const baseEnv = {
+    DEPLOYMENT_PROTECTION_USERNAME: "preview",
+    DEPLOYMENT_PROTECTION_PASSWORD: "s3cret",
+    DEPLOYMENT_PROTECTION_SECRET: "super-long-signing-secret",
+    VERCEL_AUTOMATION_BYPASS_SECRET: "bypass-secret",
+};
+
+describe("withDeploymentProtection", () => {
+    it("sets the session cookie on the Next.js redirect when bypass is in the query", async () => {
+        const middleware = withDeploymentProtection({ env: baseEnv });
+        const request = new NextRequest(
+            "https://example.com/page?x-vercel-protection-bypass=bypass-secret"
+        );
+        const response = await middleware(request);
+
+        expect(response.status).toBe(302);
+        expect(response.headers.get("Location")).toBe("https://example.com/page");
+        expect(response.cookies.get(SESSION_COOKIE_NAME)?.value).toBeTruthy();
+    });
+
+    it("does not require x-vercel-set-bypass-cookie to persist the session", async () => {
+        const middleware = withDeploymentProtection({
+            env: {
+                VERCEL_AUTOMATION_BYPASS_SECRET: "bypass-secret",
+            },
+        });
+        const request = new NextRequest(
+            "https://example.com/?x-vercel-protection-bypass=bypass-secret"
+        );
+        const response = await middleware(request);
+
+        expect(response.status).toBe(302);
+        expect(response.cookies.get(SESSION_COOKIE_NAME)?.value).toBeTruthy();
+    });
+});

--- a/packages/deployment-protection/src/middleware.ts
+++ b/packages/deployment-protection/src/middleware.ts
@@ -187,7 +187,7 @@ function copyHeaders(from: Response, to: NextResponse, skipLocation: boolean): v
  * export default withDeploymentProtection();
  * export const config = {
  *   matcher: [
- *     "/((?!_next/static|_next/image|favicon.ico|.*\\\\.(?:svg|png|jpg|jpeg|gif|webp|ico|css|js|map|txt|xml|woff2?)$).*)",
+ *     "/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp|ico|css|js|map|txt|xml|woff2?)$).*)",
  *   ],
  * };
  * ```
@@ -198,7 +198,7 @@ function copyHeaders(from: Response, to: NextResponse, skipLocation: boolean): v
  * export const proxy = withDeploymentProtection();
  * export const config = {
  *   matcher: [
- *     "/((?!_next/static|_next/image|favicon.ico|.*\\\\.(?:svg|png|jpg|jpeg|gif|webp|ico|css|js|map|txt|xml|woff2?)$).*)",
+ *     "/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp|ico|css|js|map|txt|xml|woff2?)$).*)",
  *   ],
  * };
  * ```

--- a/packages/deployment-protection/src/middleware.ts
+++ b/packages/deployment-protection/src/middleware.ts
@@ -18,6 +18,18 @@ export type WithDeploymentProtectionArgs =
     | [NextMiddleware]
     | [NextMiddleware, DeploymentProtectionOptions];
 
+type CookieSameSite = "lax" | "strict" | "none";
+
+interface ParsedSetCookie {
+    name: string;
+    value: string;
+    httpOnly?: boolean;
+    secure?: boolean;
+    path?: string;
+    maxAge?: number;
+    sameSite?: CookieSameSite;
+}
+
 function isOptions(value: unknown): value is DeploymentProtectionOptions {
     return (
         typeof value === "object" &&
@@ -25,6 +37,100 @@ function isOptions(value: unknown): value is DeploymentProtectionOptions {
         !Array.isArray(value) &&
         typeof value !== "function"
     );
+}
+
+function decodeCookieValue(value: string): string {
+    try {
+        return decodeURIComponent(value);
+    } catch {
+        return value;
+    }
+}
+
+function parseSetCookie(header: string): ParsedSetCookie | null {
+    const parts = header
+        .split(";")
+        .map(part => part.trim())
+        .filter(Boolean);
+    const first = parts.shift();
+
+    if (!first) {
+        return null;
+    }
+
+    const separator = first.indexOf("=");
+
+    if (separator <= 0) {
+        return null;
+    }
+
+    const parsed: ParsedSetCookie = {
+        name: first.slice(0, separator),
+        value: decodeCookieValue(first.slice(separator + 1)),
+    };
+
+    for (const part of parts) {
+        const [rawKey, ...rest] = part.split("=");
+        const key = rawKey?.toLowerCase();
+        const attrValue = rest.join("=");
+
+        if (key === "httponly") {
+            parsed.httpOnly = true;
+        } else if (key === "secure") {
+            parsed.secure = true;
+        } else if (key === "path") {
+            parsed.path = attrValue;
+        } else if (key === "max-age") {
+            const maxAge = Number(attrValue);
+
+            if (!Number.isNaN(maxAge)) {
+                parsed.maxAge = maxAge;
+            }
+        } else if (key === "samesite") {
+            const sameSite = attrValue.toLowerCase();
+
+            if (sameSite === "lax" || sameSite === "strict" || sameSite === "none") {
+                parsed.sameSite = sameSite;
+            }
+        }
+    }
+
+    return parsed;
+}
+
+function readSetCookieHeaders(headers: Headers): string[] {
+    if (typeof headers.getSetCookie === "function") {
+        const cookies = headers.getSetCookie();
+
+        if (cookies.length > 0) {
+            return cookies;
+        }
+    }
+
+    const single = headers.get("set-cookie");
+    return single ? [single] : [];
+}
+
+/**
+ * Next.js middleware only reliably applies cookies set via `NextResponse.cookies`.
+ * Copying raw `Set-Cookie` headers onto a redirect is ignored by the runtime.
+ */
+function applyCookies(from: Response, to: NextResponse): void {
+    for (const header of readSetCookieHeaders(from.headers)) {
+        const cookie = parseSetCookie(header);
+
+        if (!cookie) {
+            continue;
+        }
+
+        to.cookies.set(cookie.name, cookie.value, {
+            httpOnly: cookie.httpOnly,
+            secure: cookie.secure,
+            path: cookie.path,
+            maxAge: cookie.maxAge,
+            sameSite: cookie.sameSite,
+        });
+    }
 }
 
 function toNextResponse(request: NextRequest, response: Response): NextResponse {
@@ -38,6 +144,7 @@ function toNextResponse(request: NextRequest, response: Response): NextResponse 
         );
 
         copyHeaders(response, redirectResponse, /* skipLocation */ true);
+        applyCookies(response, redirectResponse);
         return redirectResponse;
     }
 
@@ -46,27 +153,16 @@ function toNextResponse(request: NextRequest, response: Response): NextResponse 
         statusText: response.statusText,
     });
     copyHeaders(response, nextResponse, false);
+    applyCookies(response, nextResponse);
     return nextResponse;
 }
 
 function copyHeaders(from: Response, to: NextResponse, skipLocation: boolean): void {
-    const setCookies =
-        typeof from.headers.getSetCookie === "function" ? from.headers.getSetCookie() : [];
-
-    if (setCookies.length > 0) {
-        for (const cookie of setCookies) {
-            to.headers.append("Set-Cookie", cookie);
-        }
-    }
-
     from.headers.forEach((value, key) => {
         const lower = key.toLowerCase();
 
         if (lower === "set-cookie") {
-            // Already copied via getSetCookie when available; fall back otherwise.
-            if (setCookies.length === 0) {
-                to.headers.append("Set-Cookie", value);
-            }
+            // Applied via NextResponse.cookies so the middleware runtime honors them.
             return;
         }
 
@@ -91,7 +187,7 @@ function copyHeaders(from: Response, to: NextResponse, skipLocation: boolean): v
  * export default withDeploymentProtection();
  * export const config = {
  *   matcher: [
- *     "/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp|ico|css|js|map|txt|xml|woff2?)$).*)",
+ *     "/((?!_next/static|_next/image|favicon.ico|.*\\\\.(?:svg|png|jpg|jpeg|gif|webp|ico|css|js|map|txt|xml|woff2?)$).*)",
  *   ],
  * };
  * ```
@@ -102,7 +198,7 @@ function copyHeaders(from: Response, to: NextResponse, skipLocation: boolean): v
  * export const proxy = withDeploymentProtection();
  * export const config = {
  *   matcher: [
- *     "/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp|ico|css|js|map|txt|xml|woff2?)$).*)",
+ *     "/((?!_next/static|_next/image|favicon.ico|.*\\\\.(?:svg|png|jpg|jpeg|gif|webp|ico|css|js|map|txt|xml|woff2?)$).*)",
  *   ],
  * };
  * ```


### PR DESCRIPTION
When `x-vercel-protection-bypass` is present as a query param, persist a signed `__becklyn_dp_session` cookie so later requests stay authenticated without keeping the secret in the URL.

## Why

Opening a preview with `?x-vercel-protection-bypass=…` should establish a session. That was unreliable:

- Next.js middleware/proxy ignored raw `Set-Cookie` headers on redirects (`NextResponse.cookies` is required)
- Bypass-only setups (no username/password / `DEPLOYMENT_PROTECTION_SECRET`) skipped session signing entirely, so the follow-up request after the redirect was unauthenticated

`x-vercel-set-bypass-cookie` is still optional and only adds the raw `__becklyn_dp_bypass` cookie. Header-only automation stays one-shot.

## Changes

- Always attach `__becklyn_dp_session` for a valid bypass query param
- Fall back to `VERCEL_AUTOMATION_BYPASS_SECRET` as the HMAC key when no dedicated session secret exists
- Copy cookies onto `NextResponse` via `cookies.set()` so redirects actually persist them
- Tests for query-only bypass, bypass-only config, edge middleware, and the Next.js wrapper

Base branch is `main`.