### PR TITLE
fix(deployment-protection): stop tests from wiping dist during release

### DIFF
--- a/packages/deployment-protection/package.json
+++ b/packages/deployment-protection/package.json
@@ -11,9 +11,9 @@
     "scripts": {
         "lint": "eslint . --max-warnings 0 && prettier --check \"./**/*.{ts,tsx,md,json,mjs}\"",
         "fix": "eslint . --fix && prettier --write \"./**/*.{ts,tsx,md,json,mjs}\"",
-        "test": "npm run build && vitest run",
+        "test": "vitest run",
         "build": "rm -rf dist && tsc -p tsconfig-es.json && tsc -p tsconfig-cjs.json && node ./scripts/build-edge-bundles.mjs",
-        "prepublishOnly": "npm run lint && npm run test"
+        "prepublishOnly": "npm run lint && npm run build && npm run test"
     },
     "devDependencies": {
         "@becklyn/eslint": "*",

--- a/turbo.json
+++ b/turbo.json
@@ -4,7 +4,8 @@
     "tasks": {
         "build": {
             "dependsOn": ["^build"],
-            "inputs": ["$TURBO_DEFAULT$", ".env*"]
+            "inputs": ["$TURBO_DEFAULT$", ".env*"],
+            "outputs": ["dist/**", ".next/**", "!.next/cache/**"]
         },
         "storybook-build": {
             "dependsOn": ["^build"],
@@ -14,7 +15,7 @@
             "dependsOn": ["^lint"]
         },
         "test": {
-            "dependsOn": ["^test"]
+            "dependsOn": ["build"]
         },
         "check-types": {
             "dependsOn": ["^check-types"]


### PR DESCRIPTION
## Problem

`@becklyn/deployment-protection` cannot be published because the release pipeline (`turbo run build lint test`) fails while building the private auth-proxy app:

```
Module not found: Can’t resolve ‘@becklyn/deployment-protection’
```

JS Lint and Build on `main` succeeds because it only runs `turbo build`. Release runs **build, lint, and test together**.

`@becklyn/deployment-protection`’s test script was `npm run build && vitest run`, which starts with `rm -rf dist`. Turbo scheduled that in parallel with `@becklyn/deployment-protection-auth-proxy#build`. Next.js then resolved the workspace package to `dist/cjs/index.js` while `dist` had been deleted.

## Fix

- Run package tests against the existing build (`vitest run`) instead of rebuilding and deleting `dist`.
- Make the turbo `test` task depend on `build`, so bundle tests still see `dist/edge.mjs` / `dist/storybook.mjs`.
- Cache `dist/**` and `.next/**` as build outputs so cache hits restore files other packages import.

No changeset: this is a pipeline fix so the already-bumped `0.4.2` can publish.