### PR TITLE
fix(deployment-protection): send session cookie in third-party iframes

### DIFF
--- a/.changeset/session-samesite-none.md
+++ b/.changeset/session-samesite-none.md
@@ -1,0 +1,5 @@
+---
+"@becklyn/deployment-protection": patch
+---
+
+Set `__becklyn_dp_session` as `SameSite=None; Secure` on HTTPS so the session is sent when a preview is embedded in a third-party iframe (e.g. Contentful live preview). HTTP localhost stays `SameSite=Lax` because browsers reject `SameSite=None` without `Secure`. Also fix `appendSetCookie` so `sameSite: "none"` serializes as `SameSite=None` instead of `SameSite=Noneone`.

--- a/packages/deployment-protection/README.md
+++ b/packages/deployment-protection/README.md
@@ -240,7 +240,7 @@ When platform Deployment Protection is disabled, **this package** enforces the b
 6. Valid session or bypass cookie → allow
 7. Else → HTML login page (password and/or Sign in with Vercel)
 
-Session cookie: `__becklyn_dp_session` (HMAC-SHA256, 14 days by default).
+Session cookie: `__becklyn_dp_session` (HMAC-SHA256, 14 days by default). On HTTPS it is `HttpOnly; Secure; SameSite=None` so a logged-in session is sent when the preview is embedded in a third-party iframe (e.g. Contentful live preview). On HTTP (localhost) it stays `SameSite=Lax` because browsers reject `SameSite=None` without `Secure`.
 
 ## Disable without code changes
 
@@ -283,6 +283,8 @@ Recommended matcher (must be pasted as a string literal in your middleware/proxy
 - Do not put the raw handoff secret in query strings — only signatures/tokens.
 - Turn off paid Vercel Password Protection / seat-heavy sharing once this is live; keep `VERCEL_AUTOMATION_BYPASS_SECRET` configured for tooling.
 - Middleware is a convenience edge check — do not treat it as the only control for highly sensitive data.
+- `__becklyn_dp_session` is `SameSite=None` on HTTPS so third-party iframes can send it. That cookie only decides whether the preview may load; apps must still CSRF-protect their own state-changing endpoints. OAuth state/PKCE cookies stay `SameSite=Lax`.
+- Safari (and some Chrome third-party-cookie settings) may still block unpartitioned third-party cookies even with `SameSite=None`.
 
 ## License
 

--- a/packages/deployment-protection/src/handler.test.ts
+++ b/packages/deployment-protection/src/handler.test.ts
@@ -3,7 +3,8 @@ import { hasPasswordAuth, hasVercelAuth, isProtectionActive, resolveConfig } fro
 import { BYPASS_COOKIE_NAME, BYPASS_HEADER, SESSION_COOKIE_NAME } from "./constants";
 import { timingSafeEqualString } from "./crypto";
 import { handleDeploymentProtection } from "./handler";
-import { createSessionToken, verifySessionToken } from "./session";
+import { createSessionToken, sessionCookieOptions, verifySessionToken } from "./session";
+import { appendSetCookie } from "./vercel-oauth";
 
 const baseEnv = {
     DEPLOYMENT_PROTECTION_USERNAME: "preview",
@@ -14,6 +15,11 @@ const baseEnv = {
 function setCookieHeader(response: Response): string {
     const cookies = response.headers.getSetCookie?.() ?? [response.headers.get("Set-Cookie") ?? ""];
     return cookies.join("\n");
+}
+
+function namedSetCookie(response: Response, name: string): string {
+    const cookies = response.headers.getSetCookie?.() ?? [response.headers.get("Set-Cookie") ?? ""];
+    return cookies.find(cookie => cookie.startsWith(`${name}=`)) ?? "";
 }
 
 function cookieHeaderFromResponse(response: Response, name: string): string | null {
@@ -30,6 +36,10 @@ function cookieHeaderFromResponse(response: Response, name: string): string | nu
     }
 
     return null;
+}
+
+function expectSameSiteNone(cookie: string) {
+    expect(cookie).toMatch(/;\s*SameSite=None(?:;|$)/);
 }
 
 describe("resolveConfig", () => {
@@ -76,6 +86,38 @@ describe("session tokens", () => {
         const token = await createSessionToken("secret", "password", "preview", 60);
         const tampered = token.replace(/\./, ".x");
         expect(await verifySessionToken("secret", tampered)).toBeNull();
+    });
+
+    it("uses SameSite=None; Secure on HTTPS and Lax on HTTP", () => {
+        expect(sessionCookieOptions(60, true)).toEqual({
+            httpOnly: true,
+            sameSite: "none",
+            secure: true,
+            path: "/",
+            maxAge: 60,
+        });
+        expect(sessionCookieOptions(60, false)).toEqual({
+            httpOnly: true,
+            sameSite: "lax",
+            secure: false,
+            path: "/",
+            maxAge: 60,
+        });
+    });
+});
+
+describe("appendSetCookie", () => {
+    it("serializes SameSite=None without a trailing suffix", () => {
+        const response = new Response(null);
+        appendSetCookie(response, "test", "value", {
+            httpOnly: true,
+            secure: true,
+            sameSite: "none",
+            path: "/",
+        });
+        expect(response.headers.get("Set-Cookie")).toBe(
+            "test=value; Path=/; HttpOnly; Secure; SameSite=None"
+        );
     });
 });
 
@@ -131,6 +173,30 @@ describe("handleDeploymentProtection", () => {
         expect(response!.status).toBe(302);
         expect(response!.headers.get("Location")).toBe("https://example.com/dashboard");
         expect(response!.headers.get("Set-Cookie")).toContain(SESSION_COOKIE_NAME);
+        expectSameSiteNone(namedSetCookie(response!, SESSION_COOKIE_NAME));
+        expect(namedSetCookie(response!, SESSION_COOKIE_NAME)).toContain("Secure");
+    });
+
+    it("sets the session cookie as SameSite=Lax on HTTP", async () => {
+        const body = new URLSearchParams({
+            __becklyn_dp: "1",
+            username: "preview",
+            password: "s3cret",
+            return_to: "/",
+        });
+
+        const response = await handleDeploymentProtection(
+            new Request("http://localhost:3000/", {
+                method: "POST",
+                headers: { "content-type": "application/x-www-form-urlencoded" },
+                body,
+            }),
+            { env: baseEnv }
+        );
+
+        expect(response).not.toBeNull();
+        expect(namedSetCookie(response!, SESSION_COOKIE_NAME)).toMatch(/;\s*SameSite=Lax(?:;|$)/);
+        expect(namedSetCookie(response!, SESSION_COOKIE_NAME)).not.toMatch(/SameSite=None/);
     });
 
     it("does not open-redirect on malicious return_to after login", async () => {
@@ -227,6 +293,7 @@ describe("handleDeploymentProtection", () => {
         expect(response!.headers.get("Location")).toBe("https://example.com/page?keep=1");
         expect(setCookieHeader(response!)).toContain(SESSION_COOKIE_NAME);
         expect(setCookieHeader(response!)).not.toContain(BYPASS_COOKIE_NAME);
+        expectSameSiteNone(namedSetCookie(response!, SESSION_COOKIE_NAME));
 
         const sessionCookie = cookieHeaderFromResponse(response!, SESSION_COOKIE_NAME);
         expect(sessionCookie).toBeTruthy();
@@ -352,6 +419,7 @@ describe("auth proxy mode on protected apps", () => {
         expect(response!.status).toBe(302);
         expect(response!.headers.get("Location")).toBe("https://app.example.com/home");
         expect(response!.headers.get("Set-Cookie")).toContain(SESSION_COOKIE_NAME);
+        expectSameSiteNone(namedSetCookie(response!, SESSION_COOKIE_NAME));
     });
 
     it("shows Sign in with Vercel when only auth proxy is configured", async () => {

--- a/packages/deployment-protection/src/middleware.test.ts
+++ b/packages/deployment-protection/src/middleware.test.ts
@@ -24,6 +24,7 @@ describe("withDeploymentProtection", () => {
         expect(response.status).toBe(302);
         expect(response.headers.get("Location")).toBe("https://example.com/page");
         expect(response.cookies.get(SESSION_COOKIE_NAME)?.value).toBeTruthy();
+        expect(response.headers.get("set-cookie")?.toLowerCase()).toContain("samesite=none");
     });
 
     it("does not require x-vercel-set-bypass-cookie to persist the session", async () => {
@@ -53,7 +54,7 @@ describe("JSDoc matcher examples", () => {
     it("use two backslashes so copied regex excludes static assets", () => {
         for (const file of ["middleware.ts", "storybook.ts"] as const) {
             const source = packageSource(file);
-            const matches = [...source.matchAll(/\.\*(\\+)\./g)];
+            const matches = [...source.matchAll(/\.\*(\\\\+)\./g)];
             expect(matches.length).toBeGreaterThan(0);
 
             for (const match of matches) {

--- a/packages/deployment-protection/src/session.ts
+++ b/packages/deployment-protection/src/session.ts
@@ -76,7 +76,9 @@ export async function verifySessionToken(
 export function sessionCookieOptions(maxAge: number, secure: boolean) {
     return {
         httpOnly: true,
-        sameSite: "lax" as const,
+        // SameSite=None; Secure is required for third-party iframes (e.g. Contentful).
+        // Browsers reject SameSite=None without Secure, so HTTP (localhost) stays Lax.
+        sameSite: (secure ? "none" : "lax") as "none" | "lax",
         secure,
         path: "/",
         maxAge,

--- a/packages/deployment-protection/src/vercel-oauth.ts
+++ b/packages/deployment-protection/src/vercel-oauth.ts
@@ -213,6 +213,12 @@ export function clearOAuthCookies(response: Response, secure: boolean): void {
     }
 }
 
+const SAME_SITE_LABEL: Record<"lax" | "strict" | "none", string> = {
+    lax: "Lax",
+    strict: "Strict",
+    none: "None",
+};
+
 export function appendSetCookie(
     response: Response,
     name: string,
@@ -242,9 +248,7 @@ export function appendSetCookie(
     }
 
     if (options.sameSite) {
-        parts.push(
-            `SameSite=${options.sameSite === "none" ? "None" : options.sameSite[0]!.toUpperCase()}${options.sameSite.slice(1)}`
-        );
+        parts.push(`SameSite=${SAME_SITE_LABEL[options.sameSite]}`);
     }
 
     response.headers.append("Set-Cookie", parts.join("; "));


### PR DESCRIPTION
## Why

`__becklyn_dp_session` was `SameSite=Lax`, so it is **not** sent when a protected preview is loaded in a cross-site iframe (e.g. `app.contentful.com` → `*.becklyn.app`). Lax only allows same-site requests and top-level GET navigations — an iframe is neither.

## Security

This is OK for this cookie specifically:

- The session only answers “may this browser open the preview?”. It does not authorize app mutations.
- Apps still need their own CSRF protection for state-changing endpoints.
- OAuth state / nonce / PKCE cookies stay `SameSite=Lax`.
- `SameSite=None` is only set together with `Secure` (HTTPS). HTTP localhost stays `Lax` because browsers reject `None` without `Secure`.

Safari (and some Chrome third-party-cookie settings) can still block unpartitioned third-party cookies even with `SameSite=None`. `Partitioned` / CHIPS would not help here: login happens first-party, the iframe is a different top-level site.

## Changes

- Set `__becklyn_dp_session` to `SameSite=None; Secure` on HTTPS.
- Fix `appendSetCookie` so `sameSite: "none"` serializes as `SameSite=None` instead of the previous `SameSite=Noneone` (which Next.js middleware then dropped).

## Test plan

- [x] Package unit tests (`npm test` in `@becklyn/deployment-protection`)
- [ ] After publish/upgrade: log in on a preview, then load it in Contentful live preview and confirm `__becklyn_dp_session` is sent on the iframe document request.