### PR TITLE
fix(deployment-protection): honor kill switch over automation bypass secret

### DIFF
--- a/.changeset/kill-switch-wins-over-bypass.md
+++ b/.changeset/kill-switch-wins-over-bypass.md
@@ -1,0 +1,5 @@
+---
+"@becklyn/deployment-protection": patch
+---
+
+Honor `DEPLOYMENT_PROTECTION_ENABLED=false` even when `VERCEL_AUTOMATION_BYPASS_SECRET` is set, so the kill switch disables the entire gate (including automation bypass).

--- a/packages/deployment-protection/README.md
+++ b/packages/deployment-protection/README.md
@@ -7,7 +7,7 @@ Use this instead of (or after disabling) Vercel platform Deployment Protection w
 - a **shared username/password** from env vars
 - optional **Sign in with Vercel** for team members
 - always-on **automation bypass** via `x-vercel-protection-bypass` / `VERCEL_AUTOMATION_BYPASS_SECRET`
-- a kill switch (`DEPLOYMENT_PROTECTION_ENABLED`, on by default)
+- a kill switch (`DEPLOYMENT_PROTECTION_ENABLED`, on by default) that disables the **entire** gate, including automation bypass
 
 Protection runs in:
 
@@ -124,6 +124,8 @@ export default withDeploymentProtection(async request => {
 
 At least one of password auth, Vercel OAuth (proxy or direct), or a bypass secret must be configured while enabled. If nothing is configured, the gate stays inactive (fail-open) so local dev is not bricked.
 
+`DEPLOYMENT_PROTECTION_ENABLED=false` **always wins**. A set `VERCEL_AUTOMATION_BYPASS_SECRET` (Vercel injects this on most projects) does not keep the gate active.
+
 ### 3. Sign in with Vercel via auth-proxy (recommended)
 
 Register **one** OAuth callback URL on a shared [Sign in with Vercel](https://vercel.com/docs/sign-in-with-vercel) app:
@@ -230,6 +232,8 @@ The header form stays one-shot (no cookies) so CI/Playwright can send it on each
 
 When platform Deployment Protection is disabled, **this package** enforces the bypass secret so CI/Playwright keep working the same way.
 
+Bypass is only enforced while the gate is enabled. `DEPLOYMENT_PROTECTION_ENABLED=false` turns off challenges **and** bypass handling.
+
 ## Behaviour
 
 1. Disabled / misconfigured → pass through
@@ -248,7 +252,7 @@ Session cookie: `__becklyn_dp_session` (HMAC-SHA256, 14 days by default). On HTT
 DEPLOYMENT_PROTECTION_ENABLED=false
 ```
 
-Redeploy. Middleware stays installed but is a no-op.
+Redeploy. Middleware stays installed but is a no-op — including when `VERCEL_AUTOMATION_BYPASS_SECRET` is set.
 
 ## API
 

--- a/packages/deployment-protection/src/config.ts
+++ b/packages/deployment-protection/src/config.ts
@@ -25,6 +25,97 @@ function isEnabled(env: EnvMap): boolean {
     return !FALSEY.has(raw.toLowerCase());
 }
 
+function assignDefined(target: EnvMap, key: string, value: string | undefined): void {
+    if (value !== undefined) {
+        target[key] = value;
+    }
+}
+
+/**
+ * Next.js middleware / Edge only inlines statically analyzable `process.env.NAME` access.
+ * Spreading `process.env` is often `{}` there, so a runtime
+ * `VERCEL_AUTOMATION_BYPASS_SECRET` could activate the gate while the kill switch is invisible.
+ */
+function readProcessEnv(): EnvMap {
+    if (typeof process === "undefined") {
+        return {};
+    }
+
+    const env: EnvMap = { ...process.env };
+
+    assignDefined(env, "DEPLOYMENT_PROTECTION_ENABLED", process.env.DEPLOYMENT_PROTECTION_ENABLED);
+    assignDefined(
+        env,
+        "DEPLOYMENT_PROTECTION_USERNAME",
+        process.env.DEPLOYMENT_PROTECTION_USERNAME
+    );
+    assignDefined(
+        env,
+        "DEPLOYMENT_PROTECTION_PASSWORD",
+        process.env.DEPLOYMENT_PROTECTION_PASSWORD
+    );
+    assignDefined(env, "DEPLOYMENT_PROTECTION_SECRET", process.env.DEPLOYMENT_PROTECTION_SECRET);
+    assignDefined(
+        env,
+        "DEPLOYMENT_PROTECTION_HANDOFF_SECRET",
+        process.env.DEPLOYMENT_PROTECTION_HANDOFF_SECRET
+    );
+    assignDefined(
+        env,
+        "DEPLOYMENT_PROTECTION_AUTH_PROXY_URL",
+        process.env.DEPLOYMENT_PROTECTION_AUTH_PROXY_URL
+    );
+    assignDefined(
+        env,
+        "VERCEL_AUTOMATION_BYPASS_SECRET",
+        process.env.VERCEL_AUTOMATION_BYPASS_SECRET
+    );
+    assignDefined(
+        env,
+        "DEPLOYMENT_PROTECTION_BYPASS_SECRET",
+        process.env.DEPLOYMENT_PROTECTION_BYPASS_SECRET
+    );
+    assignDefined(
+        env,
+        "DEPLOYMENT_PROTECTION_ALLOWED_ORIGINS",
+        process.env.DEPLOYMENT_PROTECTION_ALLOWED_ORIGINS
+    );
+    assignDefined(
+        env,
+        "DEPLOYMENT_PROTECTION_AUTH_PROXY_ALLOWED_ORIGINS",
+        process.env.DEPLOYMENT_PROTECTION_AUTH_PROXY_ALLOWED_ORIGINS
+    );
+    assignDefined(
+        env,
+        "DEPLOYMENT_PROTECTION_VERCEL_CLIENT_ID",
+        process.env.DEPLOYMENT_PROTECTION_VERCEL_CLIENT_ID
+    );
+    assignDefined(
+        env,
+        "NEXT_PUBLIC_VERCEL_APP_CLIENT_ID",
+        process.env.NEXT_PUBLIC_VERCEL_APP_CLIENT_ID
+    );
+    assignDefined(env, "VERCEL_APP_CLIENT_ID", process.env.VERCEL_APP_CLIENT_ID);
+    assignDefined(
+        env,
+        "DEPLOYMENT_PROTECTION_VERCEL_CLIENT_SECRET",
+        process.env.DEPLOYMENT_PROTECTION_VERCEL_CLIENT_SECRET
+    );
+    assignDefined(env, "VERCEL_APP_CLIENT_SECRET", process.env.VERCEL_APP_CLIENT_SECRET);
+    assignDefined(
+        env,
+        "DEPLOYMENT_PROTECTION_FORM_TITLE",
+        process.env.DEPLOYMENT_PROTECTION_FORM_TITLE
+    );
+    assignDefined(
+        env,
+        "DEPLOYMENT_PROTECTION_FORM_DESCRIPTION",
+        process.env.DEPLOYMENT_PROTECTION_FORM_DESCRIPTION
+    );
+
+    return env;
+}
+
 /**
  * Resolve runtime configuration from env (+ optional overrides).
  */
@@ -32,7 +123,7 @@ export function resolveConfig(
     options: DeploymentProtectionOptions = {}
 ): DeploymentProtectionConfig {
     const env: EnvMap = {
-        ...(typeof process !== "undefined" ? process.env : {}),
+        ...readProcessEnv(),
         ...options.env,
     };
 
@@ -114,10 +205,14 @@ export function hasVercelAuth(config: DeploymentProtectionConfig): boolean {
 /**
  * Protection only runs when enabled and at least one auth method is configured.
  * Misconfigured+enabled is treated as inactive (fail-open) so local/dev isn't bricked.
+ *
+ * `DEPLOYMENT_PROTECTION_ENABLED=false` always wins, including when
+ * `VERCEL_AUTOMATION_BYPASS_SECRET` is set (Vercel injects that on most projects).
  */
 export function isProtectionActive(config: DeploymentProtectionConfig): boolean {
-    return (
-        config.enabled &&
-        (hasPasswordAuth(config) || hasVercelAuth(config) || Boolean(config.bypassSecret))
-    );
+    if (!config.enabled) {
+        return false;
+    }
+
+    return hasPasswordAuth(config) || hasVercelAuth(config) || Boolean(config.bypassSecret);
 }

--- a/packages/deployment-protection/src/edge.test.ts
+++ b/packages/deployment-protection/src/edge.test.ts
@@ -70,4 +70,19 @@ describe("withEdgeDeploymentProtection", () => {
         const response = await middleware(new Request("https://storybook.example.com/"));
         expect(response.headers.get("x-middleware-next")).toBe("1");
     });
+
+    it("is a no-op when disabled even if the automation bypass secret is set", async () => {
+        const middleware = withEdgeDeploymentProtection({
+            env: {
+                VERCEL_AUTOMATION_BYPASS_SECRET: "bypass-secret",
+                DEPLOYMENT_PROTECTION_ENABLED: "false",
+            },
+        });
+        const response = await middleware(
+            new Request("https://storybook.example.com/?x-vercel-protection-bypass=bypass-secret")
+        );
+        expect(response.status).toBe(200);
+        expect(response.headers.get("x-middleware-next")).toBe("1");
+        expect(response.headers.get("Location")).toBeNull();
+    });
 });

--- a/packages/deployment-protection/src/handler.test.ts
+++ b/packages/deployment-protection/src/handler.test.ts
@@ -61,6 +61,18 @@ describe("resolveConfig", () => {
         expect(isProtectionActive(config)).toBe(false);
     });
 
+    it("lets the kill switch win over the automation bypass secret", () => {
+        const config = resolveConfig({
+            env: {
+                VERCEL_AUTOMATION_BYPASS_SECRET: "bypass-secret",
+                DEPLOYMENT_PROTECTION_ENABLED: "false",
+            },
+        });
+        expect(config.enabled).toBe(false);
+        expect(config.bypassSecret).toBe("bypass-secret");
+        expect(isProtectionActive(config)).toBe(false);
+    });
+
     it("detects vercel oauth config", () => {
         const config = resolveConfig({
             env: {
@@ -138,6 +150,34 @@ describe("handleDeploymentProtection", () => {
             },
         });
         expect(response).toBeNull();
+    });
+
+    it("does not enforce bypass when the kill switch is off", async () => {
+        const env = {
+            VERCEL_AUTOMATION_BYPASS_SECRET: "bypass-secret",
+            DEPLOYMENT_PROTECTION_ENABLED: "false",
+        };
+
+        const anonymous = await handleDeploymentProtection(new Request("https://example.com/"), {
+            env,
+        });
+        expect(anonymous).toBeNull();
+
+        const withHeader = await handleDeploymentProtection(
+            new Request("https://example.com/api/health", {
+                headers: {
+                    [BYPASS_HEADER]: "bypass-secret",
+                },
+            }),
+            { env }
+        );
+        expect(withHeader).toBeNull();
+
+        const withQuery = await handleDeploymentProtection(
+            new Request("https://example.com/?x-vercel-protection-bypass=bypass-secret"),
+            { env }
+        );
+        expect(withQuery).toBeNull();
     });
 
     it("returns a login page when unauthenticated", async () => {

--- a/packages/deployment-protection/src/middleware.test.ts
+++ b/packages/deployment-protection/src/middleware.test.ts
@@ -41,6 +41,23 @@ describe("withDeploymentProtection", () => {
         expect(response.status).toBe(302);
         expect(response.cookies.get(SESSION_COOKIE_NAME)?.value).toBeTruthy();
     });
+
+    it("passes through when the kill switch is off even if the bypass secret is set", async () => {
+        const middleware = withDeploymentProtection({
+            env: {
+                VERCEL_AUTOMATION_BYPASS_SECRET: "bypass-secret",
+                DEPLOYMENT_PROTECTION_ENABLED: "false",
+            },
+        });
+        const request = new NextRequest(
+            "https://example.com/?x-vercel-protection-bypass=bypass-secret"
+        );
+        const response = await middleware(request);
+
+        expect(response.status).toBe(200);
+        expect(response.headers.get("Location")).toBeNull();
+        expect(response.cookies.get(SESSION_COOKIE_NAME)).toBeUndefined();
+    });
 });
 
 function packageSource(relativePath: string): string {
@@ -61,5 +78,13 @@ describe("JSDoc matcher examples", () => {
                 expect(match[1], file).toHaveLength(2);
             }
         }
+    });
+});
+
+describe("config env access", () => {
+    it("reads the kill switch and bypass secret via static process.env members", () => {
+        const source = packageSource("config.ts");
+        expect(source).toContain("process.env.DEPLOYMENT_PROTECTION_ENABLED");
+        expect(source).toContain("process.env.VERCEL_AUTOMATION_BYPASS_SECRET");
     });
 });


### PR DESCRIPTION
## Summary

`DEPLOYMENT_PROTECTION_ENABLED=false` now always disables the entire gate, even when `VERCEL_AUTOMATION_BYPASS_SECRET` is set (Vercel injects that on most projects).

Previously the kill switch could lose in Next.js middleware / Edge because spreading `process.env` is often an empty object there, while the bypass secret is still present at runtime. That made bypass-only protection stay active on otherwise public deploys.

## Changes

- Read known env vars via static `process.env.NAME` access so Next.js can inline the kill switch.
- Short-circuit `isProtectionActive` when `enabled` is false so the bypass secret cannot keep the gate on.
- Pass through requests (no login page, no bypass redirect) when the kill switch is off.
- Document the precedence and add unit tests for config, handler, Next middleware, and Edge.

## Test plan

- [x] `npm run lint` / `npm run test` / `npm run build` in `packages/deployment-protection`
- [ ] Confirm a deploy with `DEPLOYMENT_PROTECTION_ENABLED=false` and `VERCEL_AUTOMATION_BYPASS_SECRET` set does not challenge traffic or rewrite bypass query params